### PR TITLE
Initial implementation of zoom to selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can configure this to point to your running instance of geOrchestra, with ca
 If you will try to do requests to absolute URLs, you may be redirected to use the proxy. (the request will be transformed in something like `/mapstore/proxy?url=...`).
 Make sure that this entry point(s) (configured in `proxyConfig.json`) are able to resolve the URL passed as parameter.
 If supported, you can add the URL to `useCors` entry in `localConfig.json` (see mapstore documentation).
+
 #### Authentication
 
 If you need to login, you can run geOrchestra locally and use the header extension to fake the login (see [Dev documentation of GeOrchestra](https://docs.georchestra.geo-solutions.it/en/latest/developer/index.html#mocking-security)). When you will try to login from the login menu, you will be logged in as the user indicated in the headers.

--- a/js/__tests__/app-test.js
+++ b/js/__tests__/app-test.js
@@ -1,7 +1,0 @@
-const expect = require('expect');
-
-describe('test fake', () => {
-    it('test', () => {
-        expect(true).toBe(true);
-    });
-});

--- a/js/extension/actions/cadastrapp.js
+++ b/js/extension/actions/cadastrapp.js
@@ -13,6 +13,7 @@ export const ADD_PLOT_SELECTION = "CADASTRAPP:ADD_PLOT_SELECTION";
 export const REMOVE_PLOT_SELECTION = "CADASTRAPP:REMOVE_PLOT_SELECTION";
 export const SELECT_PLOTS = "CADASTRAPP:SELECT_PLOTS";
 export const DESELECT_PLOTS = "CADASTRAPP:DESELECT_PLOTS";
+export const ZOOM_TO_SELECTION = "CADASTRAPP:ZOOM_TO_SELECTION";
 /**
  * Triggered on cadastrapp activation
  */
@@ -115,4 +116,11 @@ export const selectPlots = (plots) => ({
 export const deselectPlots = (plots) => ({
     type: DESELECT_PLOTS,
     plots
+});
+
+/**
+ * Triggers a zoom to the current selection.
+ */
+export const zoomToSelection = () => ({
+    type: ZOOM_TO_SELECTION
 });

--- a/js/extension/components/plot/PlotSelectionToolbar.jsx
+++ b/js/extension/components/plot/PlotSelectionToolbar.jsx
@@ -14,6 +14,7 @@ import ToolbarButton from '@mapstore/components/misc/toolbar/ToolbarButton';
 
 
 export default function PlotSelectionToolbar({
+    zoomToSelection = () => {},
     removePlots = () => {},
     onClick = () => { },
     selectedPlots = []
@@ -32,7 +33,7 @@ export default function PlotSelectionToolbar({
                 disabled: !atLeaseOneSelected,
                 glyph: "zoom-in",
                 tooltip: "Zoom", // localize
-                onClick: () => { alert("TODO"); }
+                onClick: zoomToSelection
             }, {
                 disabled: !atLeaseOneSelected,
                 glyph: "th-list",

--- a/js/extension/epics/cadastrapp.js
+++ b/js/extension/epics/cadastrapp.js
@@ -6,3 +6,5 @@ export { syncLayerForPlots } from './layerSync';
 
 // epics that implement map selection
 export { cadastrappMapSelection } from './mapSelection';
+
+export { zoomToSelection } from './events';

--- a/js/extension/epics/events.js
+++ b/js/extension/epics/events.js
@@ -1,0 +1,22 @@
+
+import Rx from 'rxjs';
+import { ZOOM_TO_SELECTION } from '../actions/cadastrapp';
+import { getCurrentPlotFeatures, getSelectedFeatures } from '../selectors/cadastrapp';
+import { zoomToExtent } from '@mapstore/actions/map';
+import bbox from '@turf/bbox';
+
+/**
+ * Performs a zoom to extent to the current selection.
+ * If no feature selected, zooms to the whole set of the current plots table.
+ */
+export function zoomToSelection(action$, store) {
+    return action$.ofType(ZOOM_TO_SELECTION).switchMap(() => {
+        const selectedFeatures = getSelectedFeatures(store.getState()) ?? [];
+        const features = getCurrentPlotFeatures(store.getState()) ?? [];
+        const zoomToFeatures = selectedFeatures.length >= 0 ? selectedFeatures : features;
+        if (zoomToFeatures.length >= 0) {
+            return Rx.Observable.of(zoomToExtent(bbox({type: "FeatureCollection", features: zoomToFeatures}), "EPSG:4326"));
+        }
+        return Rx.Observable.empty();
+    });
+}

--- a/js/extension/epics/setup.js
+++ b/js/extension/epics/setup.js
@@ -18,7 +18,8 @@ import {
     SETUP,
     TEAR_DOWN,
     setConfiguration,
-    loading
+    loading,
+    toggleSelectionTool
 } from '../actions/cadastrapp';
 
 
@@ -98,6 +99,7 @@ export const cadastrappSetup = (action$, { getState = () => { } }) =>
 export const cadastrappTearDown = action$ =>
     action$.ofType(TEAR_DOWN).switchMap(() =>
         Rx.Observable.of(
-            removeAdditionalLayer(CADASTRAPP_RASTER_LAYER_ID, CADASTRAPP_OWNER),
-            removeAdditionalLayer(CADASTRAPP_VECTOR_LAYER_ID, CADASTRAPP_OWNER)
+            toggleSelectionTool(),
+            removeAdditionalLayer({id: CADASTRAPP_RASTER_LAYER_ID, owner: CADASTRAPP_OWNER}),
+            removeAdditionalLayer({id: CADASTRAPP_VECTOR_LAYER_ID, owner: CADASTRAPP_OWNER})
         ));

--- a/js/extension/plugins/cadastrapp/PlotSelection.jsx
+++ b/js/extension/plugins/cadastrapp/PlotSelection.jsx
@@ -10,7 +10,8 @@ import {
     setActivePlotSelection,
     selectPlots,
     deselectPlots,
-    removePlots
+    removePlots,
+    zoomToSelection
 } from '../../actions/cadastrapp';
 
 import {
@@ -28,6 +29,7 @@ const PlotsSelection = connect((state) => ({
     onRowsSelected: selectPlots,
     onRowsDeselected: deselectPlots,
     removePlots: removePlots,
+    zoomToSelection: zoomToSelection,
     onTabDelete: () => removePlotSelection()
 })(PS);
 

--- a/js/extension/reducers/cadastrapp.js
+++ b/js/extension/reducers/cadastrapp.js
@@ -11,7 +11,8 @@ import {
     DESELECT_PLOTS,
     SET_CONFIGURATION,
     TOGGLE_SELECTION,
-    TOGGLE_SEARCH
+    TOGGLE_SEARCH,
+    TEAR_DOWN
 } from '../actions/cadastrapp';
 
 /**
@@ -152,6 +153,11 @@ export default function cadastrapp(state = {
             set(`plots`, newPlots),
             set(`activePlotSelection`, Math.max(state.activePlotSelection - 1, 0))
         )(state);
+    }
+    case TEAR_DOWN: {
+        return {
+            plots: []
+        };
     }
     case SET_ACTIVE_PLOT_SELECTION: {
         return set('activePlotSelection', action.active, state);

--- a/js/extension/selectors/cadastrapp.js
+++ b/js/extension/selectors/cadastrapp.js
@@ -95,7 +95,7 @@ export function selectedPlotIdsSelector(state) {
  */
 export function getCurrentPlotData(state) {
     const current = currentPlotsSelector(state);
-    return current?.data;
+    return current?.data ?? [];
 }
 export function getSelectedStyle() {
     return {
@@ -133,8 +133,8 @@ export function getCurrentPlotFeatures(state) {
 }
 export function getSelectedPlots(state) {
     const selectedIds = selectedPlotIdsSelector(state);
-    const plots = plotsSelector(state) ?? [];
-    return plots.filter(({ parcelle }) => selectedIds.includes(parcelle));
+    const data = getCurrentPlotData(state) ?? [];
+    return data.filter(({ parcelle }) => selectedIds.includes(parcelle));
 }
 export function getSelectedFeatures(state) {
     return getSelectedPlots(state).map(({feature}) => feature);


### PR DESCRIPTION
This adds an initial implementation of #9 and provides some fixes for setup/tear-down of the panel.
The finalization of #9 requires to add to MapStore some layout info, in order to zoom to Extent with the correct right offset (actually hardcoded in layout epic)
I'm going to do a proposal for this in a MapStore issue