### PR TITLE
#19: Configure plugin help url

### DIFF
--- a/assets/index.json
+++ b/assets/index.json
@@ -2,6 +2,9 @@
   "plugins": [
     {
       "name": "Cadastrapp",
+      "defaultConfig": {
+        "helpUrl": "https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur"
+      },
       "dependencies": [
         "BurgerMenu"
       ]

--- a/assets/translations/data.en-US.json
+++ b/assets/translations/data.en-US.json
@@ -2,7 +2,11 @@
     "locale": "en-US",
     "messages": {
         "cadastrapp": {
-            "title": "Cadastrapp"
+            "title": "Cadastrapp",
+            "toolbar": {
+                "zoomTo": "Zoom to results extent",
+                "help": "Help"
+            }
         }
     }
 }

--- a/assets/translations/data.fr-FR.json
+++ b/assets/translations/data.fr-FR.json
@@ -2,7 +2,11 @@
     "locale": "fr-FR",
     "messages": {
         "cadastrapp": {
-            "title": "Cadastrapp"
+            "title": "Cadastrapp",
+            "toolbar": {
+                "zoomTo": "Zoomer sur l'étendue des résultats",
+                "help": "Aidez-moi"
+            }
         }
     }
 }

--- a/assets/translations/data.it-IT.json
+++ b/assets/translations/data.it-IT.json
@@ -2,7 +2,11 @@
     "locale": "it-IT",
     "messages": {
         "cadastrapp": {
-            "title": "Cadastrapp"
+            "title": "Cadastrapp",
+            "toolbar": {
+                "zoomTo": "Zoom sull'estensione dei risultati",
+                "help": "Aiuto"
+            }
         }
     }
 }

--- a/js/extension/constants.js
+++ b/js/extension/constants.js
@@ -59,3 +59,5 @@ export const SEARCH_TYPES = {
     COOWNER: "coowner"
 };
 export const MIN_PARCELLE_ID_LENGTH = 14;
+
+export const DEFAULT_HELP_URL = 'https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur';

--- a/js/extension/plugins/cadastrapp/Main.jsx
+++ b/js/extension/plugins/cadastrapp/Main.jsx
@@ -13,11 +13,11 @@ import { CONTROL_NAME } from '../../constants';
  */
 export default connect(state => ({
     enabled: state.controls && state.controls[CONTROL_NAME] && state.controls[CONTROL_NAME].enabled || false
-}))(function Main({ enabled }) {
+}))(function Main({ enabled, ...props }) {
     if (!enabled) return null;
     return (<div className="cadastrapp">
         <Header/>
-        <MainToolbar/>
+        <MainToolbar {...props}/>
         <MainPanel/>
     </div>);
 });

--- a/js/extension/plugins/cadastrapp/MainToolbar.jsx
+++ b/js/extension/plugins/cadastrapp/MainToolbar.jsx
@@ -8,13 +8,13 @@ import Preferences from './toolbar/Preferences';
 import HelpButton from './toolbar/Help';
 
 
-export default function MainToolbar() {
+export default function MainToolbar(props) {
     return (<div className="side-bar pull-left">
         <ZoomTo/>
         <SelectionTools/>
         <SearchTools/>
         <RequestLanding />
         <Preferences/>
-        <HelpButton/>
+        <HelpButton helpUrl={props?.helpUrl}/>
     </div>);
-};
+}

--- a/js/extension/plugins/cadastrapp/toolbar/Help.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/Help.jsx
@@ -1,15 +1,33 @@
-import React from 'react';
-import TButton from './TButton';
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import React from "react";
+import { Tooltip } from "react-bootstrap";
+import Message from "@mapstore/components/I18N/Message";
+import TButton from "./TButton";
+import { DEFAULT_HELP_URL } from "@js/extension/constants";
 
-// ["question-sign", "help", "Help"]
 /**
- * Implements help button
+ * Implements the help button of Cadastrapp
+ * @param {object} props Component props
+ * @param {string} props.helpUrl configured help link of the plugin
  */
-export default function HelpButton() {
-    return <>
-        <TButton glyph="question-sign" onClick={() => {
-            // TODO: get the URL of the help button
-            window.open("https://portail.sig.rennesmetropole.fr/actus/aide/cadastre", '_blank');
-        }}/>;
-    </>;
+export default function HelpButton({ helpUrl = DEFAULT_HELP_URL }) {
+    return (
+        <TButton
+            tooltip={
+                <Tooltip id={"zoomTo"}>
+                    <Message msgId={"cadastrapp.toolbar.help"} />
+                </Tooltip>
+            }
+            glyph="question-sign"
+            onClick={() => {
+                window.open(helpUrl, "_blank");
+            }}
+        />
+    );
 }

--- a/js/extension/plugins/cadastrapp/toolbar/__tests__/Help-test.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/__tests__/Help-test.jsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import React from 'react';
+import expect from 'expect';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+import Help from '../Help';
+
+describe("Help", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('test render Help', () => {
+        ReactDOM.render(<Help />, document.getElementById('container'));
+        const container = document.getElementById('container');
+        expect(container).toBeTruthy();
+        const zoomButton = document.querySelector('.glyphicon-question-sign');
+        expect(zoomButton).toBeTruthy();
+    });
+    it('test trigger help link', () => {
+        const helpUrl = "http://www.domain.com/documentation";
+        const spyOnWindow = expect.spyOn(window, 'open');
+        ReactDOM.render(<Help helpUrl={helpUrl} />, document.getElementById('container'));
+        const zoomButton = document.querySelector('button');
+        expect(zoomButton).toBeTruthy();
+        ReactTestUtils.Simulate.click(zoomButton);
+        expect(spyOnWindow).toHaveBeenCalled();
+        expect(spyOnWindow.calls[0].arguments[0]).toEqual(helpUrl);
+    });
+});

--- a/localConfig.json
+++ b/localConfig.json
@@ -279,7 +279,12 @@
             },
             "FeedbackMask"
         ],
-        "desktop": ["Details", "Cadastrapp",
+        "desktop": ["Details", {
+          "name": "Cadastrapp",
+          "cfg": {
+            "helpUrl": "https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur"
+          }
+        },
           {
             "name": "Map",
             "cfg": {


### PR DESCRIPTION
## Description
This PR allows help url to be configured for the cadastrapp plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#19 

**What is the new behavior?**
- The help url can be configured via local config
- Url can also be configured from context creator

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
