### PR TITLE
#43 remove duplicated comptecommunal in exports

### DIFF
--- a/js/extension/components/information/PropertiesRadio.jsx
+++ b/js/extension/components/information/PropertiesRadio.jsx
@@ -60,6 +60,9 @@ export default function PropertiesRadio({
                             compteCommunal: data
                                 .filter((_, i) => selected.includes(i))
                                 .map(({ comptecommunal }) => comptecommunal)
+                                .filter(function onlyUnique(value, index, self) {
+                                    return self.indexOf(value) === index;
+                                })
                                 .join(',')
                         }).then((response) => {
                             setLoading(false);


### PR DESCRIPTION
Points 1 and 4 of #43 already fixed in previous commits. This changes fix also points 2 and 3, both caused by putting the same  comptecommunal  multiple times in the request. The original app removed duplicates before to download.
In case of this duplication PDF simply duplicates the output while csv fails with an error and this is the reason of the different results.
