### PR TITLE
#20 preference is now draggable. #47 foncier, #49 docUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,31 @@ It is based on https://github.com/geosolutions-it/MapStoreExtension with the cus
 
 It can be used also as a template to create new extensions for geOrchestra.
 
+## Plugin configuration
+
+Basically, the Urbanisme plugin allows the user to query for the NRU and the ADS data on the parcelle layer and also to print the data onto a pdf
+
+### Local config
+
+For example the plugin allows configuration of the following properties
+
+- *helpUrl* - Plugin specific help url for more details on the extension, used by the help button
+- *foncier* - activate/deactivate `foncier` functionalities
+- *popup* - settings for popup
+
+ ```javascript
+ {
+ "cfg": {
+    "helpUrl": "https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur",
+    "foncier": true,
+    "popup": {
+      "minZoom": 14,
+      "timeToShow": 1000
+    }
+  }
+ }
+ ```
+
 ## Quick Start
 
 Clone the repository with the --recursive option to automatically clone submodules.

--- a/assets/index.json
+++ b/assets/index.json
@@ -2,6 +2,8 @@
   "plugins": [
     {
       "name": "Cadastrapp",
+      "glyph": "th",
+      "docUrl":"https://github.com/georchestra/mapstore2-cadastrapp#plugin-configuration",
       "defaultConfig": {
         "helpUrl": "https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur",
         "foncier": true,

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -217,22 +217,17 @@ div.cadastrapp-modal.cadastrapp-landed-property-modal {
   font-weight: bold;
   width: 100%;
 }
-.cadastrapp-preferences-modal {
+.cadastrapp-preferences-dialog {
+  background: #fff;
   width: 400px;
-  max-width: none !important;
 }
-.cadastrapp-preferences-modal .tab-content {
-  border: solid 1px #ddd;
-  border-top: none;
+.cadastrapp-preferences-dialog .tab-content {
   overflow: hidden;
 }
-.cadastrapp-preferences-modal .tab-pane {
+.cadastrapp-preferences-dialog .tab-pane {
   padding: 10px;
 }
-.cadastrapp-preferences-modal .modal-body {
-  overflow: hidden !important;
-  width: 400px !important;
-}
+
 .cadastrapp-information-modal .modal-body {
   max-height: 85vh !important;
   overflow-y: auto !important;

--- a/js/extension/components/modals/Preferences.jsx
+++ b/js/extension/components/modals/Preferences.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import Modal from '@mapstore/components/misc/Modal';
+import Dialog from '@mapstore/components/misc/Dialog';
+import Portal from '@mapstore/components/misc/Portal';
 import StyleEditor from '../style/StyleEditor';
 
-import { Tabs, Tab, Button } from "react-bootstrap";
+import { Tabs, Tab, Button, Glyphicon } from "react-bootstrap";
 
-export default function PreferencesModal({
+export default function PreferencesDialog({
     isShown,
     onClose,
     setLayerStyle = () => {},
@@ -14,14 +15,15 @@ export default function PreferencesModal({
         "default": {}
     }
 }) {
+    if (!isShown) {
+        return null;
+    }
     return (
-        <Modal
-            dialogClassName="cadastrapp-preferences-modal"
-            show={isShown} onHide={onClose}>
-            <Modal.Header closeButton>
-                <Modal.Title>Preferences</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
+        <Portal><Dialog
+            className="cadastrapp-preferences-dialog"
+            show={isShown} >
+            <span role="header"><span>Preferences</span><button style={{ background: 'transparent', border: 'none', "float": "right" }}><Glyphicon glyph="1-close" onClick={() => onClose()} style={{  }} /></button></span>
+            <div role="body" style={{height: 200}}>
                 <Tabs defaultActiveKey={1} >
                     <Tab eventKey={1} title="Default">
                         <StyleEditor
@@ -46,11 +48,11 @@ export default function PreferencesModal({
                     </Tab>
 
                 </Tabs>
-            </Modal.Body>
-            <Modal.Footer>
+            </div>
+            <div role="footer">
                 <Button onClick={() => { setLayerStyles();}}>Set default style</Button>
                 <Button onClick={() => { onClose(); }}>Close</Button>
-            </Modal.Footer>
-        </Modal>
+            </div>
+        </Dialog></Portal>
     );
 }

--- a/js/extension/components/plot/PlotSelectionToolbar.jsx
+++ b/js/extension/components/plot/PlotSelectionToolbar.jsx
@@ -18,6 +18,7 @@ import Toolbar from '@mapstore/components/misc/toolbar/Toolbar';
 import BundleInformationModal from './BundleInformationModal';
 
 export default function PlotSelectionToolbar({
+    foncier,
     authLevel = {},
     currentData = [],
     loadInfo = () => {},
@@ -43,12 +44,14 @@ export default function PlotSelectionToolbar({
                     glyph: "zoom-in",
                     tooltip: atLeaseOneSelected ? "Zoom to selected" : "Zoom on list", // localize
                     onClick: zoomToSelection
-                }, {
-                    disabled: !onlyOneSelected,
-                    glyph: "th-list",
-                    tooltip: "Owned Unit Information", // localize
-                    onClick: () => { showLandedPropertyInformation(find(currentData, {parcelle: selectedPlots[0]})); }
-                }, {
+                }, ...(foncier
+                    ? [{
+                        disabled: !onlyOneSelected,
+                        glyph: "th-list",
+                        tooltip: "Owned Unit Information", // localize
+                        onClick: () => { showLandedPropertyInformation(find(currentData, {parcelle: selectedPlots[0]})); }
+                    }]
+                    : []), {
                     disabled: !atLeaseOneSelected,
                     glyph: "trash",
                     tooltip: "Delete Selected Plots", // localize

--- a/js/extension/components/search/CoownershipSearch.jsx
+++ b/js/extension/components/search/CoownershipSearch.jsx
@@ -70,7 +70,7 @@ export default function CoownershipSearch({ loading, onSearch = () => { }, onOwn
                 valid={isSearchValid(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER])}
                 onClear={() => resetFormState(SEARCH_TYPES.COOWNER)}
                 onSearch={() => {
-                    if (isString(searchState[SEARCH_TYPES.COOWNER]?.proprietaire && !values?.parcelle)) {
+                    if (isString(searchState[SEARCH_TYPES.COOWNER]?.proprietaire) && !values?.parcelle) {
                         onOwnersSearch(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER]);
                     } else {
                         // plot search

--- a/js/extension/plugins/cadastrapp/MainToolbar.jsx
+++ b/js/extension/plugins/cadastrapp/MainToolbar.jsx
@@ -11,7 +11,7 @@ import HelpButton from './toolbar/Help';
 export default function MainToolbar(props) {
     return (<div className="side-bar pull-left">
         <ZoomTo/>
-        <SelectionTools/>
+        <SelectionTools {...props}/>
         <SearchTools/>
         <RequestLanding />
         <Preferences/>

--- a/js/extension/plugins/cadastrapp/toolbar/Preferences.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/Preferences.jsx
@@ -3,16 +3,16 @@ import {connect} from 'react-redux';
 import { layerStylesSelector } from '../../../selectors/cadastrapp';
 
 import TButton from './TButton';// ["cog", "preferences", "Preferences"],
-import PreferencesModal from '../../../components/modals/PreferencesModal';
+import PreferencesDialog from '../../../components/modals/Preferences';
 import { setLayerStyle, setLayerStyles } from '../../../actions/cadastrapp';
 
 
-const Modal = connect(state => ({
+const Dialog = connect(state => ({
     styles: layerStylesSelector(state)
 }), {
     setLayerStyle,
     setLayerStyles
-})(PreferencesModal);
+})(PreferencesDialog);
 /**
  * Implements Preferences button and modal.
  * Allow to set-up preferences.
@@ -21,7 +21,7 @@ export default function Preferences() {
     const [isPreferencesModalShown, setPreferencesModalShown] = useState(false);
     return <>
         <TButton glyph="cog" onClick={() => setPreferencesModalShown(true)} />
-        <Modal
+        <Dialog
             isShown={isPreferencesModalShown}
             onClose={() => setPreferencesModalShown(false)}
         />

--- a/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
@@ -37,11 +37,13 @@ const BUTTONS_SETTINGS = {
  * Implement the selection tools.
  * They are mutually exclusive and allow to start a selection on map.
  */
-function SelectionTools({ currentTool, onClick = () => {} }) {
+function SelectionTools({ foncier = true, currentTool, onClick = () => {} }) {
 
     return <>
         {
-            Object.keys(SELECTION_TYPES).map(k => SELECTION_TYPES[k])
+            Object.keys(SELECTION_TYPES)
+                .filter(k => foncier ? true : k !== SELECTION_TYPES.LANDED_PROPERTY) // if foncier: false, do not show landed property button
+                .map(k => SELECTION_TYPES[k])
                 .map(toolName => {
                     const isActive = toolName === currentTool;
                     return (<TButton


### PR DESCRIPTION
- Set Preference Window as modal
- #47 make foncier option work. 
- #49 add docUrl to the extension 
- minor fix to co-owners search. Now owners window shows also in co-owners, when write only text, as well as in the owners search. If something is written in plotId, it takes priority