### PR TITLE
#71: Prevent errors due to click events on header row

### DIFF
--- a/js/extension/components/information/FiscalSubDivisions.jsx
+++ b/js/extension/components/information/FiscalSubDivisions.jsx
@@ -4,14 +4,12 @@ import FiscalSubdivisionsTable from '../table/FiscalSubdivisionsTable';
 export default function FiscalSubDivisions({ fiscalSubDiv = []}) {
     // row selection
     const [selected, setSelected] = useState([]);
-    const onRowClick = r => setSelected([r.rowIdx]);
     const onRowsSelected = (rows) => setSelected(rows.map(r => r.rowIdx));
     const onRowsDeselected = (rows) => setSelected(selected.filter(i => rows.map(r => r.rowIdx).indexOf(i) === -1));
     return (<>
         <FiscalSubdivisionsTable
             data={fiscalSubDiv}
             selected={selected}
-            onRowClick={onRowClick}
             onRowsSelected={onRowsSelected}
             onRowsDeselected={onRowsDeselected} />
     </>);

--- a/js/extension/components/information/Owners.jsx
+++ b/js/extension/components/information/Owners.jsx
@@ -14,7 +14,11 @@ export default function Owners({ owners = [], parcelle}) {
         setExpanded(!expanded);
     };
     const [selected, setSelected] = useState([]);
-    const onRowClick = r => setSelected([r.rowIdx]);
+    const onRowClick = r =>  {
+        if (r?.rowIdx >= 0) { // prevent header click
+            setSelected([r.rowIdx]);
+        }
+    };
     const onRowsSelected = (rows) => setSelected(selected.concat(rows.map(r => r.rowIdx)));
     const onRowsDeselected = (rows) => setSelected(selected.filter(i => rows.map(r => r.rowIdx).indexOf(i) === -1));
     const atLeastOneSelected = selected.length > 0;

--- a/js/extension/components/owners/Modal.jsx
+++ b/js/extension/components/owners/Modal.jsx
@@ -22,7 +22,11 @@ export default function OwnersModal({
     const [selected, setSelected] = useState([]);
     const [expanded, setExpanded] = useState(false);
     const oneSelected = selected.length === 1;
-    const onRowClick = (i) => setSelected(selected.length === 1 && selected[0] === i ? [] : [i]); // toggle row selection
+    const onRowClick = (i) => {
+        if (i >= 0 ) { // prevent header click to toggle invalid selection
+            setSelected(selected.length === 1 && selected[0] === i ? [] : [i]); // toggle row selection
+        }
+    }
     const onRowsSelected = (rows) => setSelected(selected.concat(rows.map(r => r.rowIdx)));
     const onRowsDeselected = (rows) => setSelected(selected.filter(i => rows.map(r => r.rowIdx).indexOf(i) === -1));
     return (<Modal

--- a/js/extension/components/table/BuildingsTable.jsx
+++ b/js/extension/components/table/BuildingsTable.jsx
@@ -66,7 +66,9 @@ function BuildingsTable({
         rowsCount={rows.length}
         minHeight={250}
         columns={columns}
-        onRowClick={(i, row) => onRowsSelected([{rowIdx: i, row}])}
+        onRowClick={(i, row) => {
+            if (i >= 0) { onRowsSelected([{ rowIdx: i, row }]); } // prevent header click errors
+        }}
         onRowDoubleClick={onRowDoubleClick}
         rowSelection={{
             showCheckbox: false,


### PR DESCRIPTION
#71 is due to an invalid rowClick event when clicking on header (in tables that intercept rowClick event). Fixed preventing the event to be used when rowIdx < 0 (header idx is `-1`)