### PR TITLE
#72. Add option to open on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Once the extension is installed, it can be added also to the default context by 
 The plugin allows configuration of the following properties:
 
 - *helpUrl* - Plugin specific help url for more details on the extension, used by the help button
+- *openOnLoad* - Auto open plugin the plugin on load
 - *foncier* - activate/deactivate `foncier` functionalities
 - *popup* - settings for popup
 - *styles* - styles for `Preferences`
@@ -25,6 +26,7 @@ example:
  {
  "cfg": {
     "helpUrl": "https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur",
+    "openOnLoad": false,
     "foncier": true,
     "popup": {
       "minZoom": 14,

--- a/assets/index.json
+++ b/assets/index.json
@@ -5,6 +5,7 @@
       "glyph": "th",
       "docUrl":"https://github.com/georchestra/mapstore2-cadastrapp#plugin-configuration",
       "defaultConfig": {
+        "openOnLoad": false,
         "helpUrl": "https://github.com/georchestra/cadastrapp/wiki/Guide-Utilisateur",
         "foncier": true,
         "popup": {

--- a/js/extension/enhancers/init.jsx
+++ b/js/extension/enhancers/init.jsx
@@ -1,6 +1,26 @@
 import React, { useEffect } from 'react';
 
-export default () => (Component) => ({ setUp = () => { }, tearDown = () => { }, ...props }) => {
+export default () => (Component) => ({ setUp = () => { }, tearDown = () => { }, openOnLoad, open, ...props }) => {
+    // auto open effect
+    useEffect(() => {
+        let timeout;
+        let executed = false;
+        if (openOnLoad) {
+            timeout = setTimeout(() => {
+                executed = true;
+                open();
+            }, 1500); // need to initialize first
+        }
+        return () => {
+            // clean up auto-open results
+            if (timeout && !executed) { // prevent execution
+                clearTimeout(timeout);
+            } else if (executed) {
+                props?.onClose?.(); // force clear (resets possible issues due to map layout changes by cadastrapp)
+            }
+        };
+    }, [openOnLoad]);
+    // configuration load and initial setup
     useEffect(() => {
         if (props.enabled) {
             setUp(props?.pluginCfg);

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { toggleControl } from "@mapstore/actions/controls";
+import { setControlProperty, toggleControl } from "@mapstore/actions/controls";
 
 import {Glyphicon} from 'react-bootstrap';
 import Message from "@mapstore/components/I18N/Message";
@@ -22,7 +22,8 @@ const Cadastrapp = compose(
         enabled: state.controls && state.controls[CONTROL_NAME] && state.controls[CONTROL_NAME].enabled || false,
         withButton: false
     }), {
-        onClose: toggleControl.bind(null, CONTROL_NAME, null)
+        open: () => toggleControl(CONTROL_NAME, "enabled", true),
+        onClose: () => toggleControl(CONTROL_NAME, "enabled", false)
     }),
     // setup and teardown due to open/close
     compose(


### PR DESCRIPTION
Adds option `openOnLoad` to plugin configuration. If true, the panel will auto-open when rendered.