### PR TITLE
#101 show max request message when the limit is 0

### DIFF
--- a/js/extension/components/modals/Request.jsx
+++ b/js/extension/components/modals/Request.jsx
@@ -65,7 +65,7 @@ export default function RequestFormModal({
                 });
             }
             // Set available requests from the response, else set max request from configuration
-            data.requestAvailable ? setAvailableRequest(+data.requestAvailable) : setAvailableRequest(+maxRequest);
+            data.requestAvailable || data.requestAvailable === 0 ? setAvailableRequest(+data.requestAvailable) : setAvailableRequest(+maxRequest);
             setCheckingLimit(false);
         }).catch(()=>{
             setAvailableRequest(0);


### PR DESCRIPTION
Now when limit is reached, the message is shown on list, as when you try to do too much requests at the same time.
![image](https://user-images.githubusercontent.com/1279510/109821611-718bd600-7c36-11eb-92f8-7f0bd645b2ba.png)
