### PR TITLE
#114: Plot selection export button fix for non CNIL users

### DIFF
--- a/js/extension/components/plot/PlotSelectionToolbar.jsx
+++ b/js/extension/components/plot/PlotSelectionToolbar.jsx
@@ -27,7 +27,7 @@ export default function PlotSelectionToolbar({
     showLandedPropertyInformation = () => {},
     selectedPlots = []
 }) {
-    const atLeaseOneSelected = selectedPlots.length > 0;
+    const atLeastOneSelected = selectedPlots.length > 0;
     const onlyOneSelected = selectedPlots.length === 1;
     const isDataPresent = currentData.length > 0;
     const { isCNIL1, isCNIL2 } = authLevel;
@@ -42,7 +42,7 @@ export default function PlotSelectionToolbar({
                 buttons={[{
                     disabled: !isDataPresent,
                     glyph: "zoom-in",
-                    tooltipId: atLeaseOneSelected ? "cadastrapp.result.parcelle.zoom.selection" : "cadastrapp.result.parcelle.zoom.list",
+                    tooltipId: atLeastOneSelected ? "cadastrapp.result.parcelle.zoom.selection" : "cadastrapp.result.parcelle.zoom.list",
                     onClick: zoomToSelection
                 }, ...(foncier
                     ? [{
@@ -52,19 +52,19 @@ export default function PlotSelectionToolbar({
                         onClick: () => { showLandedPropertyInformation(find(currentData, {parcelle: selectedPlots[0]})); }
                     }]
                     : []), {
-                    disabled: !atLeaseOneSelected,
+                    disabled: !atLeastOneSelected,
                     glyph: "trash",
                     tooltipId: "cadastrapp.result.parcelle.delete",
                     onClick: () => { removePlots(selectedPlots); }
                 }, {
-                    disabled: !atLeaseOneSelected,
+                    disabled: !atLeastOneSelected,
                     glyph: "info-sign",
                     tooltipId: "cadastrapp.result.parcelle.fiche",
                     onClick: () => { loadInfo(selectedPlots);}
                 }, ((isCNIL1 || isCNIL2) ? {
                     renderButton:
                         (<DropdownButton
-                            disabled={!atLeaseOneSelected}
+                            disabled={!atLeastOneSelected}
                             pullRight title={< Glyphicon glyph="export" />}>
                             <MenuItem onClick={() => exportParcellesAsCSV({ parcelles: selectedPlots }).then(downloadResponse)}>
                                 <Message msgId={"cadastrapp.result.csv.button.parcelles"} />
@@ -83,7 +83,7 @@ export default function PlotSelectionToolbar({
                             }}><Message msgId={"cadastrapp.result.csv.button.bundle"} /></MenuItem>
                         </DropdownButton>)
                 } : {
-                    disabled: !isDataPresent || !atLeaseOneSelected,
+                    disabled: !isDataPresent || !atLeastOneSelected,
                     glyph: "export",
                     tooltipId: "cadastrapp.result.csv.export",
                     onClick: () => exportParcellesAsCSV({ parcelles: selectedPlots }).then(downloadResponse)

--- a/js/extension/components/plot/PlotSelectionToolbar.jsx
+++ b/js/extension/components/plot/PlotSelectionToolbar.jsx
@@ -83,7 +83,7 @@ export default function PlotSelectionToolbar({
                             }}><Message msgId={"cadastrapp.result.csv.button.bundle"} /></MenuItem>
                         </DropdownButton>)
                 } : {
-                    disabled: !isDataPresent,
+                    disabled: !isDataPresent || !atLeaseOneSelected,
                     glyph: "export",
                     tooltipId: "cadastrapp.result.csv.export",
                     onClick: () => exportParcellesAsCSV({ parcelles: selectedPlots }).then(downloadResponse)


### PR DESCRIPTION
## Description
This PR fixes export button enabled when no plot selected, for non CNIL user

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

##Issue

**What is the current behavior?**
#114

**What is the new behavior?**
The export button will be enabled only when data present and at least one plot selected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
