### PR TITLE
#113: Info on data freshness

### DIFF
--- a/assets/translations/data.en-US.json
+++ b/assets/translations/data.en-US.json
@@ -11,6 +11,8 @@
             "loading": "Loading...",
             "nodata": "No data to display",
             "contenancedgfip": "DGFiP",
+            "dateValiditeEDIGEO": "Cadastral plan version",
+            "dateValiditeMajic": "Land data version",
             "infobulle": {
                 "parcelle": "Parcelle",
                 "commune": "Town",

--- a/assets/translations/data.fr-FR.json
+++ b/assets/translations/data.fr-FR.json
@@ -10,6 +10,8 @@
             "commune": "Commune",
             "loading": "Chargement...",
             "nodata": "Aucune donnée à afficher",
+            "dateValiditeEDIGEO": "Version du plan cadastral",
+            "dateValiditeMajic": "Version des données foncières",
             "infobulle": {
                 "parcelle": "Parcelle",
                 "commune": "Ville",

--- a/assets/translations/data.it-IT.json
+++ b/assets/translations/data.it-IT.json
@@ -3,6 +3,8 @@
     "messages": {
         "cadastrapp": {
             "title": "Cadastrapp",
+            "dateValiditeEDIGEO": "Versione planimetria catastale",
+            "dateValiditeMajic": "Versione dati terra Land",
             "toolbar": {
                 "zoomTo": "Zoom sull'estensione dei risultati",
                 "help": "Aiuto"

--- a/build/extension/commons.js
+++ b/build/extension/commons.js
@@ -1,4 +1,15 @@
 const path = require("path");
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
+const DefinePlugin = require("webpack/lib/DefinePlugin");
+
+const gitRevisionPlugin = new DefinePlugin({
+    '__COMMITHASH__': JSON.stringify(new GitRevisionPlugin({
+        commithashCommand: 'rev-parse HEAD'
+    }).commithash()),
+    '__REPOURL__': JSON.stringify(new GitRevisionPlugin({
+        branchCommand: 'remote get-url origin'
+    }).branch())
+});
 
 // common configuration between production and development for webpack
 module.exports = {
@@ -12,5 +23,6 @@ module.exports = {
     alias: {
         "@mapstore": path.resolve(__dirname, '..', '..', "MapStore2", "web", "client"),
         "@js": path.resolve(__dirname, '..', '..', "js")
-    }
+    },
+    gitRevisionPlugin
 };

--- a/build/extension/prod-webpack.config.js
+++ b/build/extension/prod-webpack.config.js
@@ -6,7 +6,7 @@ const createExtensionWebpackConfig = require('../../MapStore2/build/createExtens
 const CopyPlugin = require('copy-webpack-plugin');
 const ZipPlugin = require('zip-webpack-plugin');
 const {name} = require('../../config');
-const commons = require('./commons');
+const { gitRevisionPlugin, ...commons} = require('./commons');
 
 // the build configuration for production allow to create the final zip file, compressed accordingly
 const plugins = [
@@ -23,7 +23,8 @@ const plugins = [
             // other files have to be placed in the root, with the same name
             return path.basename(assetPath);
         }
-    })
+    }),
+    gitRevisionPlugin
 ];
 // Temp fix to not fail for svg imports. TODO: wait for a fix on mapstore createExtensionWebpackConfig
 const fileLoader = {

--- a/build/extension/webpack.config.js
+++ b/build/extension/webpack.config.js
@@ -2,7 +2,7 @@
 const createExtensionWebpackConfig = require('../../MapStore2/build/createExtensionWebpackConfig');
 
 const { name } = require('../../config');
-const commons = require('./commons');
+const { gitRevisionPlugin, ...commons } = require('./commons');
 const webpackConfig = createExtensionWebpackConfig({
     prod: false,
     name,
@@ -14,7 +14,8 @@ const webpackConfig = createExtensionWebpackConfig({
             contentBase: './assets',
             contentBasePublicPath: '/extension/'
         }
-    }
+    },
+    plugins: [ gitRevisionPlugin ]
 });
 // Temp fix to not fail for svg imports. TODO: wait for a fix on mapstore
 const fileLoader = {

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -55,9 +55,14 @@
   height: 500px;
 }
 .cadastrapp .welcome-message-versions {
-  width: 80%;
+  width: 60%;
   margin: 80px auto;
+}
+.cadastrapp .welcome-message-versions tr td:first-child {
   text-align: left;
+}
+.cadastrapp .welcome-message-versions tr td:last-child {
+  text-align: right;
 }
 .cadastrapp .welcome-message-build {
   margin-left: 0;

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -50,6 +50,21 @@
 }
 .cadastrapp .welcome-message {
   padding: 60px;
+  text-align: center;
+  position: relative;
+  height: 500px;
+}
+.cadastrapp .welcome-message-items {
+  margin-left: 0;
+  margin-top: 20px;
+}
+.cadastrapp .welcome-message-build {
+  margin-left: 0;
+  margin-top: 20px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 .cadastrapp .table {
   margin-bottom: 5px;

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -54,9 +54,10 @@
   position: relative;
   height: 500px;
 }
-.cadastrapp .welcome-message-items {
-  margin-left: 0;
-  margin-top: 20px;
+.cadastrapp .welcome-message-versions {
+  width: 80%;
+  margin: 80px auto;
+  text-align: left;
 }
 .cadastrapp .welcome-message-build {
   margin-left: 0;

--- a/js/extension/components/modals/Welcome.jsx
+++ b/js/extension/components/modals/Welcome.jsx
@@ -23,14 +23,14 @@ export default function WelcomeMessage(props) {
                 <h3 className="welcome-message-items"><Message msgId={'cadastrapp.title'}/></h3>
                 <h4 className="welcome-message-items"><Message msgId={'cadastrapp.selectTool'}/></h4>
             </div>
-            <div style={{padding: 40}}>
-                <h4 className="welcome-message-items"><Message msgId={'cadastrapp.dateValiditeEDIGEO'}/>: &nbsp;{dateValiditeEDIGEO}</h4>
-                <h4 className="welcome-message-items"><Message msgId={'cadastrapp.dateValiditeMajic'}/>: &nbsp;{dateValiditeMajic}</h4>
-            </div>
-            <h4 className="welcome-message-build">build &nbsp;
+            <table className="welcome-message-versions">
+                <tr><td><Message msgId={'cadastrapp.dateValiditeEDIGEO'}/>: </td><td>{dateValiditeEDIGEO}</td></tr>
+                <tr><td><Message msgId={'cadastrapp.dateValiditeMajic'}/>: </td><td>{dateValiditeMajic}</td></tr>
+            </table>
+            <div className="welcome-message-build">build &nbsp;
                 {/* eslint-disable-next-line no-undef */}
-                <a href={`${__REPOURL__?.replace('.git', '')}/commit/${__COMMITHASH__}`}>{__COMMITHASH__?.substr(0, 8)}</a>
-            </h4>
+                <a target="_blank" href={`${__REPOURL__?.replace('.git', '')}/commit/${__COMMITHASH__}`}>{__COMMITHASH__?.substr(0, 8)}</a>
+            </div>
         </div>
     );
 }

--- a/js/extension/components/modals/Welcome.jsx
+++ b/js/extension/components/modals/Welcome.jsx
@@ -5,21 +5,32 @@ import {
 import Message from '@mapstore/components/I18N/Message';
 
 export default function WelcomeMessage(props) {
-    let className = props.isShown ? "welcome-message" : "collapse";
-    if (props.data.length > 0) {
+    const { isShown, configuration: { dateValiditeEDIGEO = '', dateValiditeMajic = '' } = {}, data } = props;
+    let className = isShown ? "welcome-message" : "collapse";
+    if (data.length > 0) {
         className = "collapse";
     }
 
 
     return (
-        <div className={className} style={{ textAlign: "center" }}>
-            <Glyphicon glyph="search-coords"
-                style={{
-                    margin: "0px",
-                    fontSize: "36px"
-                }}/>
-            <h3 style={{ marginLeft: "0px", marginTop: "20px" }}><Message msgId={'cadastrapp.title'}/></h3>
-            <h4 style={{ marginLeft: "0px", marginTop: "20px" }}><Message msgId={'cadastrapp.selectTool'}/></h4>
+        <div className={className}>
+            <div>
+                <Glyphicon glyph="search-coords"
+                    style={{
+                        margin: "0px",
+                        fontSize: "36px"
+                    }}/>
+                <h3 className="welcome-message-items"><Message msgId={'cadastrapp.title'}/></h3>
+                <h4 className="welcome-message-items"><Message msgId={'cadastrapp.selectTool'}/></h4>
+            </div>
+            <div style={{padding: 40}}>
+                <h4 className="welcome-message-items"><Message msgId={'cadastrapp.dateValiditeEDIGEO'}/>: &nbsp;{dateValiditeEDIGEO}</h4>
+                <h4 className="welcome-message-items"><Message msgId={'cadastrapp.dateValiditeMajic'}/>: &nbsp;{dateValiditeMajic}</h4>
+            </div>
+            <h4 className="welcome-message-build">build &nbsp;
+                {/* eslint-disable-next-line no-undef */}
+                <a href={`${__REPOURL__?.replace('.git', '')}/commit/${__COMMITHASH__}`}>{__COMMITHASH__?.substr(0, 8)}</a>
+            </h4>
         </div>
     );
 }

--- a/js/extension/plugins/cadastrapp/Main.jsx
+++ b/js/extension/plugins/cadastrapp/Main.jsx
@@ -7,13 +7,15 @@ import MainToolbar from './MainToolbar';
 import Header from './Header';
 import { CONTROL_NAME } from '../../constants';
 import LandedProperty from './LandedProperty';
+import {configurationSelector} from "@js/extension/selectors/cadastrapp";
 
 /**
  * Main Container of Cadastrapp.
  * It contains the whole UI of the plugin.
  */
 export default connect(state => ({
-    enabled: state.controls && state.controls[CONTROL_NAME] && state.controls[CONTROL_NAME].enabled || false
+    enabled: state.controls && state.controls[CONTROL_NAME] && state.controls[CONTROL_NAME].enabled || false,
+    configuration: configurationSelector(state)
 }))(function Main({ enabled, ...props }) {
     if (!enabled) {
         return null;

--- a/js/extension/plugins/cadastrapp/MainPanel.jsx
+++ b/js/extension/plugins/cadastrapp/MainPanel.jsx
@@ -15,7 +15,8 @@ import PlotsSelection from './PlotSelection';
 function MainPanel({
     selectedSearchTool,
     plotSelectionData,
-    foncier
+    foncier,
+    ...props
 }) {
     return (
 
@@ -23,6 +24,7 @@ function MainPanel({
             <WelcomeMessage
                 isShown={!selectedSearchTool}
                 data={plotSelectionData}
+                configuration={props.configuration}
             />
             <SearchSection
                 selectedSearchTool={selectedSearchTool}

--- a/localConfig.json
+++ b/localConfig.json
@@ -282,7 +282,7 @@
         "desktop": ["Details", {
           "name": "Cadastrapp",
           "cfg": {
-            "helpUrl": "https://docs.georchestra.org/cadastrapp/guide_utilisateur/",
+            "helpUrl": "https://docs.georchestra.org/cadastrapp/latest/guide_utilisateur/",
             "foncier": true,
             "popup": {
               "minZoom": 14,

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
         "webpack-bundle-size-analyzer": "2.0.2",
         "webpack-cli": "4.5.0",
         "webpack-dev-server": "3.11.0",
-        "zip-webpack-plugin": "^3.0.0"
+        "zip-webpack-plugin": "^3.0.0",
+        "git-revision-webpack-plugin": "5.0.0"
     },
     "dependencies": {
         "mapstore2": "file:MapStore2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const extractThemesPlugin = require('./MapStore2/build/themes.js').extractThemes
 const ModuleFederationPlugin = require('./MapStore2/build/moduleFederation').plugin;
 const buildConfig = require('./MapStore2/build/buildConfig');
 const proxyConfig = require('./proxyConfig');
+const { gitRevisionPlugin } = require('./build/extension/commons');
 
 
 const cfg = buildConfig(
@@ -20,7 +21,7 @@ const cfg = buildConfig(
         framework: path.join(__dirname, "MapStore2", "web", "client"),
         code: [path.join(__dirname, "js"), path.join(__dirname, "MapStore2", "web", "client")]
     },
-    [extractThemesPlugin, ModuleFederationPlugin],
+    [extractThemesPlugin, ModuleFederationPlugin, gitRevisionPlugin],
     false,
     "dist/",
     '.MapStoreExtension',


### PR DESCRIPTION
## Description
This PR adds commit to display data freshness of the cadastrapp and land plan and along with build information

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#113

**What is the new behavior?**
The Cadastrapp plugin welcome area will display the dates of the cadatrapp and land plan from configuration along with the build information

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
