### PR TITLE
#123 Always show owner selection when ambiguous

### DIFF
--- a/js/extension/components/search/OwnersSearch.jsx
+++ b/js/extension/components/search/OwnersSearch.jsx
@@ -47,13 +47,7 @@ export default function OwnersSearch({ loading, onSearch = () => { }, onOwnersSe
                 valid={isSearchValid(currentTab, searchState[currentTab])}
                 onClear={() => resetFormState(currentTab)}
                 onSearch={() => {
-                    // text search opens the owners tab
-                    if (currentTab === SEARCH_TYPES.USER && isString(searchState[SEARCH_TYPES.USER]?.proprietaire)) {
-                        onOwnersSearch(SEARCH_TYPES.USER, searchState[currentTab]);
-                    } else {
-                        // plot search
-                        onSearch(currentTab, searchState[currentTab]);
-                    }
+                    onOwnersSearch(SEARCH_TYPES.USER, searchState[currentTab]);
                 }} />
         </div>
     );

--- a/js/extension/epics/search.js
+++ b/js/extension/epics/search.js
@@ -205,9 +205,14 @@ export function cadastrappOwnersSearch(action$) {
         const ddenom = isString(proprietaire) ? proprietaire : proprietaire?.value;
         return Rx.Observable.defer(() => searchType === SEARCH_TYPES.USER
             ? getProprietaire({ ddenom, birthsearch, cgocommune, details: 2 })
-            : getCoProprietaireList({ ddenom: proprietaire, cgocommune, comptecommunal, details: 1})
+            : getCoProprietaireList({ ddenom, cgocommune, comptecommunal, details: 1})
         )
-            .switchMap( owners => Rx.Observable.of(owners.length > 1 ? showOwners(owners) : search(searchType, rawParams)))
+            .switchMap( owners => Rx.Observable.of(
+                // if proprietaire was an object, a selection of the user occurred. So if owner is one, can perform search.
+                // Otherwise, always show the list of users to avoid ambiguity or to do textual search.
+                owners.length > 1 || isString(proprietaire)
+                    ? showOwners(owners)
+                    : search(searchType, rawParams)))
             .let(wrapStartStop(loading(true, 'search'), loading(false, 'search')));
     });
 }


### PR DESCRIPTION
This PR shows the user list when the selection returned anyway more than one result, to avoid ambiguity.

See #123