### PR TITLE
#134: remove the marker when cadastrapp opens

### DIFF
--- a/js/extension/epics/__tests__/setup-test.js
+++ b/js/extension/epics/__tests__/setup-test.js
@@ -12,7 +12,7 @@ import {cadastrappSetup, cadastrappTearDown} from "@js/extension/epics/cadastrap
 import { LOADING, SET_CONFIGURATION, setUp, SETUP_COMPLETED, TOGGLE_SELECTION, tearDown} from "@js/extension/actions/cadastrapp";
 import {UPDATE_ADDITIONAL_LAYER, REMOVE_ADDITIONAL_LAYER} from "@mapstore/actions/additionallayers";
 import {CLEAN_MAP_POPUPS} from "@mapstore/actions/mapPopups";
-import {TOGGLE_MAPINFO_STATE} from "@mapstore/actions/mapInfo";
+import {TOGGLE_MAPINFO_STATE, HIDE_MAPINFO_MARKER} from "@mapstore/actions/mapInfo";
 import {REGISTER_EVENT_LISTENER, UNREGISTER_EVENT_LISTENER} from "@mapstore/actions/map";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
@@ -42,10 +42,10 @@ describe("setup Epics", () => {
         mockAxios.onGet().reply(200);
         testEpic(
             cadastrappSetup,
-            7,
+            8,
             setUp(),
             actions => {
-                expect(actions.length).toBe(7);
+                expect(actions.length).toBe(8);
                 actions.map(action=>{
                     switch (action.type) {
                     case LOADING:
@@ -64,6 +64,7 @@ describe("setup Epics", () => {
                         expect(action.toolName).toBe(CONTROL_NAME);
                         break;
                     case TOGGLE_MAPINFO_STATE:
+                    case HIDE_MAPINFO_MARKER:
                         break;
                     case SETUP_COMPLETED:
                         break;
@@ -84,10 +85,10 @@ describe("setup Epics", () => {
         };
         testEpic(
             cadastrappTearDown,
-            5,
+            6,
             tearDown(),
             actions => {
-                expect(actions.length).toBe(5);
+                expect(actions.length).toBe(6);
                 actions.map(action=>{
                     switch (action.type) {
                     case TOGGLE_SELECTION:
@@ -100,6 +101,7 @@ describe("setup Epics", () => {
                         break;
                     case TOGGLE_MAPINFO_STATE:
                         break;
+                    case HIDE_MAPINFO_MARKER:
                     case UNREGISTER_EVENT_LISTENER:
                         expect(action.eventName).toBe(MOUSE_EVENT);
                         expect(action.toolName).toBe(CONTROL_NAME);

--- a/js/extension/epics/setup.js
+++ b/js/extension/epics/setup.js
@@ -3,7 +3,7 @@ import Rx from 'rxjs';
 import { wrapStartStop } from '@mapstore/observables/epics';
 import { error } from '@mapstore/actions/notifications';
 import { updateAdditionalLayer, removeAdditionalLayer } from '@mapstore/actions/additionallayers';
-import { toggleMapInfoState } from '@mapstore/actions/mapInfo';
+import { hideMapinfoMarker, toggleMapInfoState } from '@mapstore/actions/mapInfo';
 import { UPDATE_MAP_LAYOUT, updateMapLayout } from '../../../MapStore2/web/client/actions/maplayout';
 
 import { registerEventListener, unRegisterEventListener } from '@mapstore/actions/map';
@@ -94,7 +94,7 @@ export const cadastrappSetup = (action$, store) =>
                             visibility: true
                         }),
                     registerEventListener(MOUSE_EVENT, CONTROL_NAME) // Set map's mouse event trigger type
-                ]).concat([...(mapInfoEnabled ? [toggleMapInfoState()] : [])]);
+                ]).concat([...(mapInfoEnabled ? [toggleMapInfoState(), hideMapinfoMarker()] : [])]);
             })
         )
             .concat(Rx.Observable.of(setupCompleted())) // required to sync the layer the first time (if closed/reopen)


### PR DESCRIPTION
This PR removes the marker from the map, if present. as for #134
This happens when the feature info is not present but active because of this reason: https://github.com/geosolutions-it/MapStore2/issues/7111
