### PR TITLE
Change the name of the extension in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "MapStoreExtension",
+    "name": "CadastrappExtension",
     "version": "1.0.0",
-    "description": "Template project to create MapStore extensions",
+    "description": "Cadastrapp plugin for mapstore2",
     "main": "index.js",
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
Since https://github.com/geosolutions-it/MapStore2/issues/7294 raised in
some of our plateform. I just changed the name of the app to
"CadastrappExtension" in order to avoid clash between mapstore plugins.