### PR TITLE
#141: Allow text selection from react grid cell

### DIFF
--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -380,3 +380,7 @@ input.request-obj-double.form-control{
   overflow: hidden;
   white-space: nowrap;
 }
+
+.react-grid-Cell {
+  user-select: text;
+}

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -381,6 +381,6 @@ input.request-obj-double.form-control{
   white-space: nowrap;
 }
 
-.react-grid-Cell {
+.cadastrapp-modal .react-grid-Cell, .cadastrapp .react-grid-Grid .react-grid-Cell {
   user-select: text;
 }


### PR DESCRIPTION
## Description
This PR allows possibility to select texts from react grid cells

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#141 

**What is the new behavior?**
User can now `click and drag/double click` on grid cell to select a text 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
