### PR TITLE
#144: Search by commune and libcom

### DIFF
--- a/js/extension/api/api.js
+++ b/js/extension/api/api.js
@@ -90,11 +90,12 @@ export function getCommune({ libcom, cgocommune }) {
 }
 
 /**
- * Search commune by text. Min 3 chars for results
+ * Search commune by text.
+ * Min char is obtained from configuration of cadastrapp services
  * @param {string} text text to search
  */
 export function searchCommune(text) {
-    return getCommune({libcom: text});
+    return getCommune({[isNaN(text) ? "libcom" : "cgocommune"]: text});
 }
 
 /**

--- a/js/extension/components/forms/MunicipalityCombo.jsx
+++ b/js/extension/components/forms/MunicipalityCombo.jsx
@@ -4,7 +4,6 @@ import SearchCombo from './SearchCombo';
 
 export default (props) => {
     return (<SearchCombo
-        minLength={3}
         valueField="cgocommune"
         textField="label"
         search={

--- a/js/extension/components/forms/ProprietaireCombo.jsx
+++ b/js/extension/components/forms/ProprietaireCombo.jsx
@@ -4,7 +4,6 @@ import SearchCombo from './SearchCombo';
 
 export default ({ cgocommune, birthsearch = false, onSelect, ...props}) => {
     return (<SearchCombo
-        minLength={3}
         valueField="value"
         textField="label"
         onSelect={onSelect}

--- a/js/extension/components/forms/RoadCombo.jsx
+++ b/js/extension/components/forms/RoadCombo.jsx
@@ -4,7 +4,6 @@ import SearchCombo from './SearchCombo';
 
 export default ({cgocommune, ...props}) => {
     return (<SearchCombo
-        minLength={3}
         valueField="dvoilib"
         textField="label"
         search={

--- a/js/extension/components/forms/SearchCombo.jsx
+++ b/js/extension/components/forms/SearchCombo.jsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import { find, isObject } from 'lodash';
 import { Combobox as CB } from 'react-widgets';
@@ -7,6 +8,7 @@ import { Glyphicon } from "react-bootstrap";
 import localizedProps from '@mapstore/components/misc/enhancers/localizedProps';
 import { getMessageById } from '../../../../MapStore2/web/client/utils/LocaleUtils';
 import {compose, getContext, mapProps} from 'recompose';
+import { minCharToSearchSelector } from "@js/extension/selectors/cadastrapp";
 
 
 const localizeMessages = compose(
@@ -29,7 +31,9 @@ const Combobox = localizedProps('placeholder')(localizeMessages(CB));
  * A utility combo for search.
  * @params search
  */
-export default ({
+export default connect(
+    state=>({ minCharToSearch: minCharToSearchSelector(state) })
+)(({
     value = {},
     valueField,
     minLength,
@@ -41,13 +45,15 @@ export default ({
     additionalStyle = {},
     placeholder = "",
     dropUp = false,
+    minCharToSearch,
     ...props
 }) => {
+    const _minLength = minLength ?? minCharToSearch;
     const [text, setText] = useState("");
     const [busy, setBusy] = useState(false);
     const [data, setData] = useState([]);
     useEffect( () => {
-        if (text.length >= minLength) {
+        if (text.length >= _minLength) {
             setBusy(true);
             search(text).then(results => {
                 setData(results);
@@ -73,7 +79,7 @@ export default ({
                 }
             }
             data={data}
-            minLength={minLength}
+            minLength={_minLength}
             {...props}
         />
         {!hideRemove && (text || value) ? <Glyphicon glyph="remove"
@@ -92,4 +98,4 @@ export default ({
                 onSelect(undefined);
             }}/> : null}
     </div>);
-};
+});

--- a/js/extension/components/request/searchCombos/ProprietaireComboList.jsx
+++ b/js/extension/components/request/searchCombos/ProprietaireComboList.jsx
@@ -6,7 +6,6 @@ export default ({ commune, section, numero, ...props }) => {
     return (
         <SearchCombo
             dropUp
-            minLength={3}
             valueField="proprietaire"
             textField="label"
             search={ddenom =>

--- a/js/extension/constants.js
+++ b/js/extension/constants.js
@@ -69,3 +69,5 @@ export const DEFAULT_POPUP_PROPS = {
     MINZOOM: '14',
     TIMETOSHOW: 1000
 };
+
+export const DEFAULT_MIN_CHAR_TO_SEARCH = 3;

--- a/js/extension/selectors/cadastrapp.js
+++ b/js/extension/selectors/cadastrapp.js
@@ -1,6 +1,7 @@
 import {
     CADASTRAPP_RASTER_LAYER_ID,
-    CADASTRAPP_VECTOR_LAYER_ID
+    CADASTRAPP_VECTOR_LAYER_ID,
+    DEFAULT_MIN_CHAR_TO_SEARCH
 } from '../constants';
 import { additionalLayersSelector } from '@mapstore/selectors/additionallayers';
 import { userGroupSecuritySelector } from '@mapstore/selectors/security';
@@ -267,4 +268,9 @@ export function cadastrappPluginCfgSelector(state) {
 
 export function popupPluginCfgSelector(state) {
     return cadastrappPluginCfgSelector(state)?.popup ?? {};
+}
+
+export function minCharToSearchSelector(state) {
+    const { minNbCharForSearch } = configurationSelector(state) ?? {};
+    return minNbCharForSearch ?? DEFAULT_MIN_CHAR_TO_SEARCH;
 }


### PR DESCRIPTION
## Description
This PR adds fix to search by commune and libcom based on search value. Use cadastrapp service configuration for minCharToSearch value

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#144 

**What is the new behavior?**
- Delegate search by commune and libcom based on search value
- `minCharToSearch` is used from cadastrapp configuration

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
