### PR TITLE
Applying necessary changes to cadastrapp to support MapStore layout changes

### DIFF
--- a/assets/index.json
+++ b/assets/index.json
@@ -14,7 +14,7 @@
         }
       },
       "dependencies": [
-        "BurgerMenu"
+        "SidebarMenu"
       ]
     }
   ]

--- a/js/extension/actions/cadastrapp.js
+++ b/js/extension/actions/cadastrapp.js
@@ -109,10 +109,12 @@ export const tearDown = () => ({
 /**
  * Toggles map selection in one of the modes available
  * @param {string} selectionType type of selection (constants.SELECTION_TYPES)
+ * @param {boolean} resetDraw should it reset draw status or not
  */
-export const toggleSelectionTool = (selectionType) => ({
+export const toggleSelectionTool = (selectionType, resetDraw = true) => ({
     type: TOGGLE_SELECTION,
-    selectionType
+    selectionType,
+    resetDraw
 });
 
 /**

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -10,8 +10,8 @@
   overflow: hidden;
   top: 0;
   right: 0;
-  height: calc(100% - 30px);
-  width: 660px;
+  height: 100%;
+  width: 100%;
   z-index: 1000;
 }
 .cadastrapp .top {

--- a/js/extension/components/misc/panels/DockContainer.jsx
+++ b/js/extension/components/misc/panels/DockContainer.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import classnames from "classnames";
+
+const DockContainer = ({ id, children, dockStyle, className, style = {}}) => {
+    const persistentStyle = {
+        width: `calc(100% - ${(dockStyle?.right ?? 0) + (dockStyle?.left ?? 0)}px)`,
+        transform: `translateX(-${(dockStyle?.right ?? 0)}px)`,
+        pointerEvents: 'none'
+    };
+    return (
+        <div id={id} className={classnames({
+            ...(className ? {[className]: true} : {}),
+            'dock-container': true
+        })} style={{...persistentStyle, ...style}}>
+            {children}
+        </div>
+    );
+};
+
+export default DockContainer;

--- a/js/extension/components/misc/panels/DockContainer.jsx
+++ b/js/extension/components/misc/panels/DockContainer.jsx
@@ -1,6 +1,19 @@
 import React from 'react';
 import classnames from "classnames";
 
+/**
+ * Wrapper for DockablePanel with main intension to support applying of custom styling to make dock panels have proper
+ * offset depending on the sidebars presence on the page
+ * @memberof components.misc.panels
+ * @name DockContainer
+ * @param id {string} - id applied to the container
+ * @param children {JSX.Element}
+ * @param dockStyle {object} - style object obtained from mapLayoutValuesSelector and used to calculate offsets
+ * @param className {string} - class name
+ * @param style - style object to apply to the container. Can be used to overwrite styles applied by dockStyle calculations
+ * @returns {JSX.Element}
+ * @constructor
+ */
 const DockContainer = ({ id, children, dockStyle, className, style = {}}) => {
     const persistentStyle = {
         width: `calc(100% - ${(dockStyle?.right ?? 0) + (dockStyle?.left ?? 0)}px)`,

--- a/js/extension/epics/setup.js
+++ b/js/extension/epics/setup.js
@@ -155,15 +155,17 @@ export const cadastrappCloseAnnotationsOnToolToggledOn = (action$, store) =>
         });
 
 /**
- * Auto-closes cadastrapp when one of the shutdown-trigger tools is open
+ * Auto-closes cadastrapp when one of the shutdown-trigger tools is open or when Feature editor is open
  */
 export const cadastrappAutoClose = (action$, store) =>
-    action$.ofType(SET_CONTROL_PROPERTIES, SET_CONTROL_PROPERTY, TOGGLE_CONTROL)
+    action$.ofType(SET_CONTROL_PROPERTIES, SET_CONTROL_PROPERTY, TOGGLE_CONTROL, OPEN_FEATURE_GRID)
         .filter(() => isCadastrappOpen(store))
         .filter(({control, property, properties = [], type}) => {
             const state = store.getState();
-            const controlState = state.controls[control].enabled;
+            const controlState = state.controls[control]?.enabled;
             switch (type) {
+            case OPEN_FEATURE_GRID:
+                return true;
             case SET_CONTROL_PROPERTY:
             case TOGGLE_CONTROL:
                 return (property === 'enabled' || !property) && controlState && shutdownList.includes(control);
@@ -173,15 +175,6 @@ export const cadastrappAutoClose = (action$, store) =>
         })
         .map( () => {
             return setControlProperty(CONTROL_NAME, "enabled", false);
-        });
-
-export const closeCadastrappOnFeatureGridOpen = (action$) =>
-    action$.ofType(OPEN_FEATURE_GRID)
-        .switchMap( () => {
-            let actions = [
-                setControlProperty('cadastrapp', 'enabled', false)
-            ];
-            return Rx.Observable.from(actions);
         });
 
 export const toggleCadastrapToolOnAnnotationsDrawing = (action$, store) =>

--- a/js/extension/epics/setup.js
+++ b/js/extension/epics/setup.js
@@ -131,8 +131,9 @@ export const cadastrappMapLayout = (action$, store) =>
                 right: OFFSET + (layout?.right ?? 0),
                 boundingMapRect: {
                     ...(layout.boundingMapRect || {}),
-                    right: OFFSET + (layout?.boundingMapRect?.right ?? 0)
-                }
+                    right: OFFSET + (layout?.boundingSidebarRect?.right ?? 0)
+                },
+                rightPanel: true
             });
             return { ...action, source: 'cadastrapp' }; // add an argument to avoid infinite loop.
         });

--- a/js/extension/epics/setup.js
+++ b/js/extension/epics/setup.js
@@ -18,8 +18,7 @@ import {
 } from '../constants';
 
 import { getConfiguration } from '../api';
-import get from 'lodash/get';
-import { configurationSelector } from '../selectors/cadastrapp';
+import {findIndex, keys, get} from "lodash";
 
 import {
     SETUP,
@@ -29,14 +28,22 @@ import {
     loading,
     toggleSelectionTool, TOGGLE_SELECTION
 } from '../actions/cadastrapp';
-import { SET_CONTROL_PROPERTIES, setControlProperty,
-    SET_CONTROL_PROPERTY, TOGGLE_CONTROL } from '@mapstore/actions/controls';
+import {
+    SET_CONTROL_PROPERTIES,
+    SET_CONTROL_PROPERTY,
+    TOGGLE_CONTROL,
+    setControlProperty
+} from '@mapstore/actions/controls';
+import {closeFeatureGrid, OPEN_FEATURE_GRID} from "@mapstore/actions/featuregrid";
+import {resetCoordEditor, START_DRAWING} from "@mapstore/actions/annotations";
+import {configurationSelector, currentSelectionToolSelector} from '../selectors/cadastrapp';
+import {isFeatureGridOpen} from "@mapstore/selectors/featuregrid";
 import {coordinateEditorEnabledSelector} from "@mapstore/selectors/annotations";
-import {findIndex, keys} from "lodash";
+import {CHANGE_DRAWING_STATUS} from "@mapstore/actions/draw";
 
 // size o
 const OFFSET = 550; // size of cadastrapp. Maybe parametrize. Now in css + this constant
-const shutdownList = ['metadataexplorer', 'measure', 'details', 'mapcatalog', 'maptemplates', 'userExtensions', 'annotations'];
+const shutdownList = ['metadataexplorer', 'measure', 'details', 'mapcatalog', 'maptemplates', 'userExtensions', 'FeatureEditor'];
 
 /**
  * utility function to check if the cadastrapp panel is open
@@ -58,7 +65,8 @@ export const cadastrappSetup = (action$, store) =>
         let initStream$ = Rx.Observable.defer(() => getConfiguration())
             .switchMap(data => {
                 return Rx.Observable.of(setConfiguration(data));
-            });
+            })
+            .startWith(...(isFeatureGridOpen ? [closeFeatureGrid()] : []));
         const mapInfoEnabled = get(store.getState(), "mapInfo.enabled");
         return initStream$.concat(
             Rx.Observable.defer(() => {
@@ -138,14 +146,12 @@ export const cadastrappMapLayout = (action$, store) =>
             return { ...action, source: 'cadastrapp' }; // add an argument to avoid infinite loop.
         });
 
-export const cadastrappCloseAnnotationsOnOpen = (action$, store) =>
+export const cadastrappCloseAnnotationsOnToolToggledOn = (action$, store) =>
     action$.ofType(TOGGLE_SELECTION)
-        .filter(({ selectionType }) => !!selectionType
-        )
-        .filter(() => coordinateEditorEnabledSelector(store.getState())
+        .filter(({ selectionType }) => !!selectionType && coordinateEditorEnabledSelector(store.getState())
         )
         .map(() => {
-            return setControlProperty("annotations", "enabled", false);
+            return resetCoordEditor();
         });
 
 /**
@@ -169,16 +175,46 @@ export const cadastrappAutoClose = (action$, store) =>
             return setControlProperty(CONTROL_NAME, "enabled", false);
         });
 
+export const closeCadastrappOnFeatureGridOpen = (action$) =>
+    action$.ofType(OPEN_FEATURE_GRID)
+        .switchMap( () => {
+            let actions = [
+                setControlProperty('cadastrapp', 'enabled', false)
+            ];
+            return Rx.Observable.from(actions);
+        });
+
+export const toggleCadastrapToolOnAnnotationsDrawing = (action$, store) =>
+    action$.ofType(START_DRAWING, CHANGE_DRAWING_STATUS)
+        .filter(({type, status, owner}) => {
+            const currentSelectionTool = currentSelectionToolSelector(store.getState());
+            switch (type) {
+            case CHANGE_DRAWING_STATUS:
+                return !!currentSelectionTool && status === 'drawOrEdit' && owner === 'annotations';
+            case START_DRAWING:
+            default:
+                return !!currentSelectionTool;
+            }
+        })
+        .switchMap( () => {
+            let actions = [
+                toggleSelectionTool(null, false)
+            ];
+            return Rx.Observable.from(actions);
+        });
+
 /**
  * Intercept cadastrapp close event.
  * - Removes the cadastre layer from the map
  */
 export const cadastrappTearDown = (action$, {getState = ()=>{}}) =>
-    action$.ofType(TEAR_DOWN).switchMap(() =>
-        Rx.Observable.from([
-            toggleSelectionTool(),
+    action$.ofType(TEAR_DOWN).switchMap(() => {
+        const cadastrappIsDrawOwner = get(getState(), 'draw.drawOwner', false) === 'cadastrapp';
+        return Rx.Observable.from([
+            toggleSelectionTool(null, cadastrappIsDrawOwner),
             removeAdditionalLayer({id: CADASTRAPP_RASTER_LAYER_ID, owner: CADASTRAPP_OWNER}),
             removeAdditionalLayer({id: CADASTRAPP_VECTOR_LAYER_ID, owner: CADASTRAPP_OWNER}),
             cleanPopups(),
             unRegisterEventListener(MOUSE_EVENT, CONTROL_NAME) // Reset map's mouse event trigger
-        ]).concat([...(!get(getState(), "mapInfo.enabled") ? [toggleMapInfoState()] : [])]));
+        ]).concat([...(!get(getState(), "mapInfo.enabled") ? [toggleMapInfoState()] : [])]);
+    });

--- a/js/extension/epics/setup.js
+++ b/js/extension/epics/setup.js
@@ -29,9 +29,9 @@ import {
     loading,
     toggleSelectionTool, TOGGLE_SELECTION
 } from '../actions/cadastrapp';
-import { SET_CONTROL_PROPERTIES, setControlProperty } from '@mapstore/actions/controls';
-import {coordinateEditorEnabledSelector} from "../../../selectors/annotations";
-import {SET_CONTROL_PROPERTY, TOGGLE_CONTROL} from "../../../actions/controls";
+import { SET_CONTROL_PROPERTIES, setControlProperty,
+    SET_CONTROL_PROPERTY, TOGGLE_CONTROL } from '@mapstore/actions/controls';
+import {coordinateEditorEnabledSelector} from "@mapstore/selectors/annotations";
 import {findIndex, keys} from "lodash";
 
 // size o
@@ -157,11 +157,11 @@ export const cadastrappAutoClose = (action$, store) =>
             const state = store.getState();
             const controlState = state.controls[control].enabled;
             switch (type) {
-                case SET_CONTROL_PROPERTY:
-                case TOGGLE_CONTROL:
-                    return (property === 'enabled' || !property) && controlState && shutdownList.includes(control);
-                default:
-                    return findIndex(keys(properties), prop => prop === 'enabled') > -1 && controlState && shutdownList.includes(control);
+            case SET_CONTROL_PROPERTY:
+            case TOGGLE_CONTROL:
+                return (property === 'enabled' || !property) && controlState && shutdownList.includes(control);
+            default:
+                return findIndex(keys(properties), prop => prop === 'enabled') > -1 && controlState && shutdownList.includes(control);
             }
         })
         .map( () => {

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { setControlProperty, toggleControl } from "@mapstore/actions/controls";
+import { toggleControl } from "@mapstore/actions/controls";
 
 import {Glyphicon} from 'react-bootstrap';
 import Message from "@mapstore/components/I18N/Message";
@@ -51,7 +51,7 @@ export default {
             icon: <Glyphicon glyph="th" />,
             doNotHide: true,
             action: toggleControl.bind(null, CONTROL_NAME, null),
-            priority: 1
+            priority: 2
         },
         SidebarMenu: {
             name: "cadastrapp",

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -13,6 +13,7 @@ import { CONTROL_NAME } from '../constants';
 import {setUp, tearDown} from '../actions/cadastrapp';
 import cadastrapp from '../reducers/cadastrapp';
 import * as epics from '../epics/cadastrapp';
+import {mapLayoutValuesSelector} from "@js/extension/selectors/maplayout";
 
 const compose = (...functions) => args => functions.reduceRight((arg, fn) => fn(arg), args);
 
@@ -20,6 +21,8 @@ const compose = (...functions) => args => functions.reduceRight((arg, fn) => fn(
 const Cadastrapp = compose(
     connect((state) => ({
         enabled: state.controls && state.controls[CONTROL_NAME] && state.controls[CONTROL_NAME].enabled || false,
+        dockStyle: mapLayoutValuesSelector(state, { right: true, height: true}, true),
+        dockWidth: 550,
         withButton: false
     }), {
         open: () => toggleControl(CONTROL_NAME, "enabled", true),
@@ -49,6 +52,16 @@ export default {
             doNotHide: true,
             action: toggleControl.bind(null, CONTROL_NAME, null),
             priority: 1
+        },
+        SidebarMenu: {
+            name: "cadastrapp",
+            icon: <Glyphicon glyph="th" />,
+            tooltip: "cadastrapp.title",
+            text: <Message msgId="cadastrapp.title"/>,
+            doNotHide: true,
+            action: toggleControl.bind(null, CONTROL_NAME, null),
+            priority: 1,
+            position: 1000
         }
     }
 };

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -60,6 +60,7 @@ export default {
             text: <Message msgId="cadastrapp.title"/>,
             doNotHide: true,
             action: toggleControl.bind(null, CONTROL_NAME, null),
+            toggle: true,
             priority: 1,
             position: 1000
         }

--- a/js/extension/plugins/cadastrapp/Main.jsx
+++ b/js/extension/plugins/cadastrapp/Main.jsx
@@ -8,6 +8,9 @@ import Header from './Header';
 import { CONTROL_NAME } from '../../constants';
 import LandedProperty from './LandedProperty';
 import {configurationSelector} from "@js/extension/selectors/cadastrapp";
+import DockPanel from "@mapstore/components/misc/panels/DockPanel";
+import ContainerDimensions from "react-container-dimensions";
+import DockContainer from "@js/extension/components/misc/panels/DockContainer";
 
 /**
  * Main Container of Cadastrapp.
@@ -16,14 +19,31 @@ import {configurationSelector} from "@js/extension/selectors/cadastrapp";
 export default connect(state => ({
     enabled: state.controls && state.controls[CONTROL_NAME] && state.controls[CONTROL_NAME].enabled || false,
     configuration: configurationSelector(state)
-}))(function Main({ enabled, ...props }) {
+}))(function Main({ enabled, dockStyle, dockWidth, ...props }) {
     if (!enabled) {
         return null;
     }
-    return (<div className="cadastrapp">
-        <Header/>
-        <MainToolbar {...props} />
-        <MainPanel {...props} />
-        <LandedProperty />
-    </div>);
+    return (
+        <DockContainer
+            dockStyle={dockStyle}
+            id="cadastrapp-container"
+            style={{pointerEvents: 'none'}}
+        >
+            <ContainerDimensions>
+                {({ width }) => (<DockPanel
+                    open
+                    size={dockWidth / width > 1 ? width : dockWidth}
+                    position="right"
+                    bsStyle="primary"
+                    style={dockStyle}>
+                    <div className="cadastrapp">
+                        <Header/>
+                        <MainToolbar {...props} />
+                        <MainPanel {...props} />
+                        <LandedProperty />
+                    </div>
+                </DockPanel>)}
+            </ContainerDimensions>
+        </DockContainer>
+    );
 });

--- a/js/extension/selectors/maplayout.js
+++ b/js/extension/selectors/maplayout.js
@@ -1,3 +1,8 @@
+import {mapLayoutSelector} from "@mapstore/selectors/maplayout";
+import {memoize} from "lodash";
+
+export const boundingSidebarRectSelector = (state) => state.maplayout && state.maplayout.boundingSidebarRect || {};
+
 /**
  * Retrieve only specific attribute from map layout
  * @function
@@ -7,29 +12,17 @@
  * @param  {boolean} isDock flag to use dock paddings instead of toolbar paddings
  * @return {object} selected attributes of layout of the map
  */
-import {mapLayoutSelector} from "@mapstore/selectors/maplayout";
-import {memoize} from "lodash";
-
-/**
- * Get map layout bounds left, top, bottom and right
- * @function
- * @memberof selectors.mapLayout
- * @param  {object} state the state
- * @return {object} boundingMapRect {left, top, bottom, right}
- */
-export const boundingSidebarRectSelector = (state) => state.maplayout && state.maplayout.boundingSidebarRect || {};
-
 export const mapLayoutValuesSelector = memoize((state, attributes = {}, isDock = false) => {
     const layout = mapLayoutSelector(state);
     const boundingSidebarRect = boundingSidebarRectSelector(state);
     return layout && Object.keys(layout).filter(key =>
         attributes[key]).reduce((a, key) => {
-            if (isDock) {
-                return ({...a, [key]: (boundingSidebarRect[key] ?? layout[key])});
-            }
-            return ({...a, [key]: layout[key]});
-        },
-        {}) || {};
+        if (isDock) {
+            return ({...a, [key]: (boundingSidebarRect[key] ?? layout[key])});
+        }
+        return ({...a, [key]: layout[key]});
+    },
+    {}) || {};
 }, (state, attributes, isDock) =>
     JSON.stringify(mapLayoutSelector(state)) +
     JSON.stringify(boundingSidebarRectSelector(state)) +

--- a/js/extension/selectors/maplayout.js
+++ b/js/extension/selectors/maplayout.js
@@ -1,0 +1,36 @@
+/**
+ * Retrieve only specific attribute from map layout
+ * @function
+ * @memberof selectors.mapLayout
+ * @param  {object} state the state
+ * @param  {object} attributes attributes to retrieve, bool {left: true}
+ * @param  {boolean} isDock flag to use dock paddings instead of toolbar paddings
+ * @return {object} selected attributes of layout of the map
+ */
+import {mapLayoutSelector} from "@mapstore/selectors/maplayout";
+import {memoize} from "lodash";
+
+/**
+ * Get map layout bounds left, top, bottom and right
+ * @function
+ * @memberof selectors.mapLayout
+ * @param  {object} state the state
+ * @return {object} boundingMapRect {left, top, bottom, right}
+ */
+export const boundingSidebarRectSelector = (state) => state.maplayout && state.maplayout.boundingSidebarRect || {};
+
+export const mapLayoutValuesSelector = memoize((state, attributes = {}, isDock = false) => {
+    const layout = mapLayoutSelector(state);
+    const boundingSidebarRect = boundingSidebarRectSelector(state);
+    return layout && Object.keys(layout).filter(key =>
+        attributes[key]).reduce((a, key) => {
+            if (isDock) {
+                return ({...a, [key]: (boundingSidebarRect[key] ?? layout[key])});
+            }
+            return ({...a, [key]: layout[key]});
+        },
+        {}) || {};
+}, (state, attributes, isDock) =>
+    JSON.stringify(mapLayoutSelector(state)) +
+    JSON.stringify(boundingSidebarRectSelector(state)) +
+    JSON.stringify(attributes) + (isDock ? '_isDock' : ''));


### PR DESCRIPTION
## Description
This PR applies several changes and improvements to the cadastrapp to make it compatible with the updated MapStore layout (https://github.com/geosolutions-it/MapStore2/issues/8086)

1.  Extension will properly update map layout when cadastrapp panel is open. It will apply additional offset to the panel if sidebar exists.
2.  Annotations and cadastrapp tools can be open at the same time, but only one of them can perform drawing operations at a time. When cadastrapp selection tool is toggled on - geometry edit session in annotations will be cancelled, unsaved geometry will disappear. If annotations starts drawing geometry while cadastrapp has selection tool active - it will be automatically toggled off.
3. Cadastrapp panel will close when feature editor panel at the bottom is open.
4. Cadastrapp will reset drawing on close only if it's the owner of drawing.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#150 

**What is the new behavior?**
As per PR description 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
