### PR TITLE
only call getBatiments if there are buildings on the plot (#168)

### DIFF
--- a/js/extension/components/information/Buildings.jsx
+++ b/js/extension/components/information/Buildings.jsx
@@ -31,12 +31,14 @@ export default function Buildings({
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
-        setLoading(true);
-        getBatiments({ parcelle, dnubat: letter }).then((data) => {
-            setBuildings(data);
-            setSelected([]);
-            setLoading(false);
-        });
+        if (letter) {
+            setLoading(true);
+            getBatiments({ parcelle, dnubat: letter }).then((data) => {
+                setBuildings(data);
+                setSelected([]);
+                setLoading(false);
+            });
+        }
     }, [letter]);
 
     // Description


### PR DESCRIPTION
Fixes #168, might not be the best fix but it works here, no more 400 errors, when opening the info form on a plot without buildings the building tag show "no data to display", and properly displays the building if there's one on the plot.