### PR TITLE
Properly prefix section name ccosec with ccopre field

### DIFF
--- a/js/extension/components/lists/ReferenceRow.jsx
+++ b/js/extension/components/lists/ReferenceRow.jsx
@@ -49,7 +49,7 @@ export default function ReferenceRow({
             defaultOpen
             disabled={isEmpty(sections)}
             style={fieldStyle}
-            textField="ccosec"
+            textField="label"
             placeholder={'cadastrapp.parcelle.result.ccosec'}
             value={section}
             onChange={() => { }}
@@ -57,10 +57,11 @@ export default function ReferenceRow({
                 onSetValue('section', newSection);
             }}
             filter="contains"
-            data={sections.map(({ ccosec, ...rest}) => ({
+            data={sections.map(({ ccosec, ccopre, ...rest}) => ({
                 ccosec,
+                ccopre,
                 ...rest,
-                label: "" + ccosec
+                label: ccopre + ccosec
             }))}
         />
         <DropdownList

--- a/js/extension/components/table/PlotsSelectionTable.jsx
+++ b/js/extension/components/table/PlotsSelectionTable.jsx
@@ -10,7 +10,7 @@ const columns = [{
     name: "cadastrapp.parcelle.result.commune",
     resizable: true
 }, {
-    key: "ccosec",
+    key: "sectionLabel",
     width: 80,
     sortable: true,
     name: "cadastrapp.parcelle.result.ccosec",
@@ -45,8 +45,8 @@ function PlotsSelectionTable({
     if (!data) {
         return null;
     }
-    // create mixed column for address
-    const processedRows = data.map(v => ({ ...v, cadastralAddr: v.dnvoiri + " " + v.cconvo + " " + v.dvoilib }));
+    // create mixed column for address and section
+    const processedRows = data.map(v => ({ ...v, sectionLabel: v.ccopre + v.ccosec, cadastralAddr: v.dnvoiri + " " + v.cconvo + " " + v.dvoilib }));
     const rows = (({sortColumn, sortDirection} = {}) => {
         if (sortDirection === "ASC") {
             return sortBy(processedRows, sortColumn);


### PR DESCRIPTION
fixes #164, supersedes #165

there might be more occurences where `ccopre` is missing.

@MaelREBOUX ?