### PR TITLE
Style update to fix dropdown menu width

### DIFF
--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -228,9 +228,6 @@ div.cadastrapp-modal.cadastrapp-landed-property-modal {
   position: relative;
   z-index: 10000000;
 }
-.Select-menu-outer {
-  width: 160px !important;
-}
 .land-planning-mockup {
   position: fixed;
   height: 52px;


### PR DESCRIPTION
### Description
This PR updates the style override that was reducing the dropdown menu width. This issue was impacting all container applications using the extension

### Issue
https://github.com/geosolutions-it/MapStore2/issues/10693

### Screenshot
<img width="554" alt="image" src="https://github.com/user-attachments/assets/7db7ddc5-136c-4348-91cf-ccbae1f2b310">

