### PR TITLE
ISSUE-197 - Icon grouping for map selection

### DIFF
--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -335,3 +335,9 @@ input.request-obj-double.form-control{
 .cadastrapp-modal .react-grid-Cell, .cadastrapp .react-grid-Grid .react-grid-Cell {
   user-select: text;
 }
+
+.selectionToolsButton {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0 10px 0;
+}

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -336,7 +336,7 @@ input.request-obj-double.form-control{
   user-select: text;
 }
 
-.selectionToolsButton {
+.cadstrap_selectionToolsButton {
   display: flex;
   justify-content: center;
   margin: 10px 0 10px 0;

--- a/js/extension/components/search/PlotSearch.jsx
+++ b/js/extension/components/search/PlotSearch.jsx
@@ -12,6 +12,7 @@ import Identifier from '../forms/Identifier';
 import Lot from '../forms/Lot';
 import useFormState from '../../hooks/useFormState';
 import SearchButtons from './SearchButtons';
+import SelectionTools from '@js/extension/plugins/cadastrapp/toolbar/SelectionTools';
 
 export default function PlotsSearch({onSearch = () => {}, loading}) {
     const [currentTab, setCurrentTab] = useState('reference');
@@ -20,6 +21,9 @@ export default function PlotsSearch({onSearch = () => {}, loading}) {
     return (
         <div className="plots-search">
             <h3><Message msgId={'cadastrapp.parcelle.title'}/></h3>
+            <div className='selectionToolsButton'>
+                <SelectionTools {...{foncier: false}}/>
+            </div>
             <Tabs
                 className="not-scrolled-tab"
                 onSelect={k => setCurrentTab(k)}

--- a/js/extension/components/search/PlotSearch.jsx
+++ b/js/extension/components/search/PlotSearch.jsx
@@ -21,7 +21,7 @@ export default function PlotsSearch({onSearch = () => {}, loading}) {
     return (
         <div className="plots-search">
             <h3><Message msgId={'cadastrapp.parcelle.title'}/></h3>
-            <div className='selectionToolsButton'>
+            <div className='cadstrap_selectionToolsButton'>
                 <SelectionTools foncier = {false}/>
             </div>
             <Tabs

--- a/js/extension/components/search/PlotSearch.jsx
+++ b/js/extension/components/search/PlotSearch.jsx
@@ -22,7 +22,7 @@ export default function PlotsSearch({onSearch = () => {}, loading}) {
         <div className="plots-search">
             <h3><Message msgId={'cadastrapp.parcelle.title'}/></h3>
             <div className='selectionToolsButton'>
-                <SelectionTools {...{foncier: false}}/>
+                <SelectionTools foncier = {false}/>
             </div>
             <Tabs
                 className="not-scrolled-tab"

--- a/js/extension/plugins/cadastrapp/MainToolbar.jsx
+++ b/js/extension/plugins/cadastrapp/MainToolbar.jsx
@@ -11,8 +11,8 @@ import HelpButton from './toolbar/Help';
 export default function MainToolbar(props) {
     return (<div className="side-bar pull-left">
         <ZoomTo/>
-        <SelectionTools {...props}/>
         <SearchTools/>
+        <SelectionTools {...props}/>
         <RequestLanding />
         <Preferences configStyles={props.styles}/>
         <HelpButton helpUrl={props?.helpUrl}/>

--- a/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
@@ -42,8 +42,7 @@ const BUTTONS_SETTINGS = {
  * Implement the selection tools.
  * They are mutually exclusive and allow to start a selection on map.
  */
-function SelectionTools({ foncier = true, currentTool, onClick = () => {} }) {
-
+function SelectionTools({ foncier = true, currentTool="POINT", onClick = () => {} }) {
     return <>
         {
             Object.keys(SELECTION_TYPES)
@@ -55,7 +54,10 @@ function SelectionTools({ foncier = true, currentTool, onClick = () => {} }) {
                         bsStyle={isActive && "success"}
                         {...BUTTONS_SETTINGS[toolName]}
                         // if the current selection button is clicked, it turns off selection
-                        onClick={() => isActive ? onClick() : onClick(toolName)}
+                        onClick={() => {
+                            isActive ? onClick() : onClick(toolName);
+                            setCurrentTool(toolName);
+                        }}
                     />);
                 })
         }

--- a/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
@@ -47,7 +47,7 @@ function SelectionTools({ foncier = true, currentTool, onClick = () => {} }) {
     return <>
         {
             Object.keys(SELECTION_TYPES)
-                .filter(k => foncier ? true : k !== SELECTION_TYPES.LANDED_PROPERTY) // if foncier: false, do not show landed property button
+                .filter(k => foncier ? k === SELECTION_TYPES.LANDED_PROPERTY : k !== SELECTION_TYPES.LANDED_PROPERTY) // if foncier: false, do not show landed property button, if true show only landed prop button
                 .map(k => SELECTION_TYPES[k])
                 .map(toolName => {
                     const isActive = toolName === currentTool;

--- a/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { SELECTION_TYPES } from '../../../constants';
 import { toggleSelectionTool } from '../../../actions/cadastrapp';
 import { currentSelectionToolSelector } from '../../../selectors/cadastrapp';
@@ -42,7 +42,8 @@ const BUTTONS_SETTINGS = {
  * Implement the selection tools.
  * They are mutually exclusive and allow to start a selection on map.
  */
-function SelectionTools({ foncier = true, currentTool="POINT", onClick = () => {} }) {
+function SelectionTools({ foncier = true, currentTool, onClick = () => {} }) {
+    useEffect(() => onClick("POINT"), []);
     return <>
         {
             Object.keys(SELECTION_TYPES)

--- a/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
+++ b/js/extension/plugins/cadastrapp/toolbar/SelectionTools.jsx
@@ -56,7 +56,6 @@ function SelectionTools({ foncier = true, currentTool="POINT", onClick = () => {
                         // if the current selection button is clicked, it turns off selection
                         onClick={() => {
                             isActive ? onClick() : onClick(toolName);
-                            setCurrentTool(toolName);
                         }}
                     />);
                 })


### PR DESCRIPTION
Modify selection tools from main toolbar to search panel.

Should the uf search button also be moved as mentioned in [this comment](https://github.com/georchestra/mapstore2-cadastrapp/issues/197#issuecomment-2545237508) ?