### PR TITLE
ISSUE-198 - Reorganization of the plot of land interface, in particular for waste garbage cans

### DIFF
--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -80,6 +80,7 @@
 }
 .cadastrapp .searchButtonsContainer {
   display: flex;
+  max-height: 48px !important;
   align-items: center;
 }
 .searchButtons{
@@ -115,10 +116,11 @@
   min-height: 200px;
 }
 .cadastrapp .not-scrolled-tab .tab-content {
+  display: flex;
   overflow-x: visible;
   overflow-y: visible;
-  height: calc(50vh - 180px);
-  min-height: 200px;
+  /* height: calc(50vh - 180px); */
+  /* min-height: 200px; */
 }
 .cadastrapp .not-scrolled-tab .nav {
   display: flex;

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -75,9 +75,10 @@
 .cadastrapp .owners-search,
 .cadastrapp .coownership-search,
 .cadastrapp .plots-search {
-  padding: 10px;
-  max-height: 50%;
-  height: 50%;
+  margin: 10px;
+  max-height: 55%;
+  height: 55%;
+  border: solid 1px #ddd;
 }
 .cadastrapp .plots-selection {
   width: 100%;
@@ -95,7 +96,6 @@
   width: 100%;
 }
 .cadastrapp .tab-content {
-  border: solid 1px #ddd;
   border-top: none;
   overflow-x: hidden;
   overflow-y: auto;

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -78,7 +78,7 @@
   margin: 10px;
   border: solid 1px #ddd;
 }
-.cadastrapp .plots-search .searchButtonsContainer {
+.cadastrapp .searchButtonsContainer {
   display: flex;
   align-items: center;
 }

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -108,6 +108,17 @@
   height: calc(50vh - 180px);
   min-height: 200px;
 }
+.cadastrapp .not-scrolled-tab .nav {
+  display: flex;
+  flex-wrap: nowrap;
+}
+.cadastrapp .not-scrolled-tab .nav > li > a {
+  padding: 5px;
+}
+.cadastrapp .not-scrolled-tab .nav-tab {
+  justify-content: space-between;
+  width: 100%;
+}
 /* reconsider this */
 .item-row {
   width: 100%;

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -76,9 +76,16 @@
 .cadastrapp .coownership-search,
 .cadastrapp .plots-search {
   margin: 10px;
-  max-height: 55%;
-  height: 55%;
   border: solid 1px #ddd;
+}
+.cadastrapp .plots-search .searchButtonsContainer {
+  display: flex;
+  align-items: center;
+}
+.searchButtons{
+  float: none !important;
+  margin: 10px;
+  margin-left: auto;
 }
 .cadastrapp .plots-selection {
   width: 100%;

--- a/js/extension/cadastrapp.css
+++ b/js/extension/cadastrapp.css
@@ -102,6 +102,11 @@
   font-weight: bold;
   width: 100%;
 }
+.cadastrapp .plotSelectionTabActionButtons {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
 .cadastrapp .tab-content {
   border-top: none;
   overflow-x: hidden;
@@ -125,6 +130,15 @@
 .cadastrapp .not-scrolled-tab .nav-tab {
   justify-content: space-between;
   width: 100%;
+}
+.cadastrapp .plotPanel a {
+  padding: 10px !important;
+}
+.cadastrapp .plotPanel .btn-default {
+  background-color: rgba(255, 0, 0, 0);
+}
+.cadastrapp .plotPanel.active .btn-default {
+  color: black;
 }
 /* reconsider this */
 .item-row {

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -71,10 +71,7 @@ function PlotSelectionTabActionButtons({onNewTab = () => {}}) {
 }
 
 function DeletePlot ({
-    index, 
-    isDrop=false,
-    onTabDelete,
-    MAX_TABS
+    onDelete = () => {},
     }) {    
     return (
         <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
@@ -83,7 +80,7 @@ function DeletePlot ({
                 confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
                 onClick={(e) => {
                     e.stopPropagation();
-                    onTabDelete(!isDrop ? index : index + (MAX_TABS - 1));
+                    onDelete();
                     }}>
                 <Glyphicon glyph="remove" />
             </ConfirmButton>
@@ -114,7 +111,7 @@ function PlotTabs({
                         {plots.slice(0, plots.length > MAX_TABS ? MAX_TABS - 1 : MAX_TABS).map((plot, index) => (
                             <NavItem role="tab" eventKey={index} className="plotPanel">
                                 {getPlotTitle(plot, index)}
-                                <DeletePlot index={index} onTabDelete={onTabDelete} MAX_TABS={MAX_TABS}/>
+                                <DeletePlot onDelete={() => onTabDelete(index)}/>
                             </NavItem>
                         ))}
                         {plots.length > MAX_TABS
@@ -122,7 +119,7 @@ function PlotTabs({
                                 {plots.slice(MAX_TABS - 1).map((plot, index) => (
                                     <MenuItem eventKey={index + MAX_TABS - 1} className="plotPanel">
                                         {getPlotTitle(plot, index + MAX_TABS - 1)}
-                                        <DeletePlot index={index} isDrop={true} onTabDelete={onTabDelete} MAX_TABS={MAX_TABS}/>
+                                        <DeletePlot onDelete={() => onTabDelete(index + (MAX_TABS - 1))}/>
                                     </MenuItem>
                                 ))}
                             </NavDropdown>

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -57,22 +57,15 @@ function PlotSelectionTabContent({
     );
 }
 
-function PlotSelectionTabActionButtons({onNewTab = () => {}, onTabDelete = () => {}}) {
+function PlotSelectionTabActionButtons({onNewTab = () => {}}) {
     return (
-        <ButtonGroup style={{position: "absolute", top: "50%", transform: "translateY(-50%)"}}>
+        <ButtonGroup className="plotSelectionTabActionButtons">
             <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.addTab'}/></Tooltip>}>
                 <Button
                     onClick={onNewTab}
                 ><span className="glyphicon glyphicon-plus"></span>
                 </Button>
             </OverlayTrigger>
-            {/* <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
-                <ConfirmButton
-                    confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                    onClick={onTabDelete}>
-                    <Glyphicon glyph="trash" />
-                </ConfirmButton>
-            </OverlayTrigger> */}
         </ButtonGroup>
     );
 }
@@ -98,9 +91,9 @@ function PlotTabs({
             defaultActiveKey={active}>
             <Row className="clearfix">
                 <Col sm={12}>
-                    <Nav bsStyle="tabs">
+                    <Nav bsStyle="tabs" className={plots.length >= MAX_TABS ? "full" : ""}>
                         {plots.slice(0, plots.length > MAX_TABS ? MAX_TABS - 1 : MAX_TABS).map((plot, index) => (
-                            <NavItem role="tab" eventKey={index}>
+                            <NavItem role="tab" eventKey={index} href="javascript:void(0)" className="plotPanel">
                                 {getPlotTitle(plot, index)}
                                 <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
                                     <ConfirmButton
@@ -114,8 +107,15 @@ function PlotTabs({
                         {plots.length > MAX_TABS
                             ? <NavDropdown title={active < MAX_TABS - 1 ? "More..." : getPlotTitle(plots[active], active)}>
                                 {plots.slice(MAX_TABS - 1).map((plot, index) => (
-                                    <MenuItem eventKey={index + MAX_TABS - 1}>
+                                    <MenuItem eventKey={index + MAX_TABS - 1} href="javascript:void(0)" className="plotPanel">
                                         {getPlotTitle(plot, index + MAX_TABS - 1)}
+                                        <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
+                                            <ConfirmButton
+                                                confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
+                                                onClick={() => {onRowsSelected(); onTabDelete(index);}}>
+                                                <Glyphicon glyph="remove" />
+                                            </ConfirmButton>
+                                        </OverlayTrigger>
                                     </MenuItem>
                                 ))}
                             </NavDropdown>

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -59,22 +59,20 @@ function PlotSelectionTabContent({
 
 function PlotSelectionTabActionButtons({onNewTab = () => {}, onTabDelete = () => {}}) {
     return (
-        <ButtonGroup className="pull-right">
+        <ButtonGroup style={{position: "absolute", top: "50%", transform: "translateY(-50%)"}}>
             <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.addTab'}/></Tooltip>}>
                 <Button
-                    className="pull-right"
                     onClick={onNewTab}
                 ><span className="glyphicon glyphicon-plus"></span>
                 </Button>
             </OverlayTrigger>
-            <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
+            {/* <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
                 <ConfirmButton
-                    className="pull-right"
                     confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
                     onClick={onTabDelete}>
                     <Glyphicon glyph="trash" />
                 </ConfirmButton>
-            </OverlayTrigger>
+            </OverlayTrigger> */}
         </ButtonGroup>
     );
 }
@@ -84,6 +82,8 @@ function PlotTabs({
     onTabChange,
     data,
     plots,
+    onTabDelete = () => {},
+    onRowsSelected,
     ...props
 }) {
 
@@ -102,6 +102,13 @@ function PlotTabs({
                         {plots.slice(0, plots.length > MAX_TABS ? MAX_TABS - 1 : MAX_TABS).map((plot, index) => (
                             <NavItem role="tab" eventKey={index}>
                                 {getPlotTitle(plot, index)}
+                                <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
+                                    <ConfirmButton
+                                        confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
+                                        onClick={() => {onRowsSelected(); onTabDelete(index);}}>
+                                        <Glyphicon glyph="remove" />
+                                    </ConfirmButton>
+                                </OverlayTrigger>
                             </NavItem>
                         ))}
                         {plots.length > MAX_TABS

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -70,6 +70,27 @@ function PlotSelectionTabActionButtons({onNewTab = () => {}}) {
     );
 }
 
+function DeletePlot ({
+    index, 
+    isDrop=false,
+    onTabDelete,
+    MAX_TABS
+    }) {    
+    return (
+        <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
+            <ConfirmButton
+                href="javascript:void(0)"
+                confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onTabDelete(!isDrop ? index : index + (MAX_TABS - 1));
+                    }}>
+                <Glyphicon glyph="remove" />
+            </ConfirmButton>
+        </OverlayTrigger>
+    )
+}
+
 function PlotTabs({
     active,
     onTabChange,
@@ -93,17 +114,7 @@ function PlotTabs({
                         {plots.slice(0, plots.length > MAX_TABS ? MAX_TABS - 1 : MAX_TABS).map((plot, index) => (
                             <NavItem role="tab" eventKey={index} className="plotPanel">
                                 {getPlotTitle(plot, index)}
-                                <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
-                                    <ConfirmButton
-                                        href="javascript:void(0)"
-                                        confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            onTabDelete(index);
-                                            }}>
-                                        <Glyphicon glyph="remove" />
-                                    </ConfirmButton>
-                                </OverlayTrigger>
+                                <DeletePlot index={index} onTabDelete={onTabDelete} MAX_TABS={MAX_TABS}/>
                             </NavItem>
                         ))}
                         {plots.length > MAX_TABS
@@ -111,17 +122,7 @@ function PlotTabs({
                                 {plots.slice(MAX_TABS - 1).map((plot, index) => (
                                     <MenuItem eventKey={index + MAX_TABS - 1} className="plotPanel">
                                         {getPlotTitle(plot, index + MAX_TABS - 1)}
-                                        <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
-                                            <ConfirmButton  
-                                                href="javascript:void(0)"
-                                                confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    onTabDelete(index + (MAX_TABS - 1));
-                                                    }}>
-                                                <Glyphicon glyph="remove" />
-                                            </ConfirmButton>
-                                        </OverlayTrigger>
+                                        <DeletePlot index={index} isDrop={true} onTabDelete={onTabDelete} MAX_TABS={MAX_TABS}/>
                                     </MenuItem>
                                 ))}
                             </NavDropdown>

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -78,11 +78,10 @@ function PlotTabs({
     onTabDelete = (index) => {index},
     ...props
 }) {
-
     const MAX_TABS = 3; // max number of tabs
     const getPlotTitle = (plot, index) => {
         return plot?.title ?? ("Selection " + (index + 1).toString());
-    };
+    };    
     return (
         <Tab.Container
             onSelect={onTabChange}
@@ -98,7 +97,10 @@ function PlotTabs({
                                     <ConfirmButton
                                         href="javascript:void(0)"
                                         confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                        onClick={() => {onTabDelete(index);}}>
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onTabDelete(index);
+                                            }}>
                                         <Glyphicon glyph="remove" />
                                     </ConfirmButton>
                                 </OverlayTrigger>
@@ -113,7 +115,10 @@ function PlotTabs({
                                             <ConfirmButton  
                                                 href="javascript:void(0)"
                                                 confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                                onClick={() => {onTabDelete(index + (MAX_TABS - 1));}}>
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    onTabDelete(index + (MAX_TABS - 1));
+                                                    }}>
                                                 <Glyphicon glyph="remove" />
                                             </ConfirmButton>
                                         </OverlayTrigger>

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -76,7 +76,6 @@ function PlotTabs({
     data,
     plots,
     onTabDelete = (index) => {index},
-    onRowsSelected,
     ...props
 }) {
 
@@ -93,10 +92,11 @@ function PlotTabs({
                 <Col sm={12}>
                     <Nav bsStyle="tabs" className={plots.length >= MAX_TABS ? "full" : ""}>
                         {plots.slice(0, plots.length > MAX_TABS ? MAX_TABS - 1 : MAX_TABS).map((plot, index) => (
-                            <NavItem role="tab" eventKey={index} href="javascript:void(0)" className="plotPanel">
+                            <NavItem role="tab" eventKey={index} className="plotPanel">
                                 {getPlotTitle(plot, index)}
                                 <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
                                     <ConfirmButton
+                                        href="javascript:void(0)"
                                         confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
                                         onClick={() => {onTabDelete(index);}}>
                                         <Glyphicon glyph="remove" />
@@ -107,12 +107,13 @@ function PlotTabs({
                         {plots.length > MAX_TABS
                             ? <NavDropdown title={active < MAX_TABS - 1 ? "More..." : getPlotTitle(plots[active], active)}>
                                 {plots.slice(MAX_TABS - 1).map((plot, index) => (
-                                    <MenuItem eventKey={index + MAX_TABS - 1} href="javascript:void(0)" className="plotPanel">
+                                    <MenuItem eventKey={index + MAX_TABS - 1} className="plotPanel">
                                         {getPlotTitle(plot, index + MAX_TABS - 1)}
                                         <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
-                                            <ConfirmButton
+                                            <ConfirmButton  
+                                                href="javascript:void(0)"
                                                 confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                                onClick={() => {onTabDelete(index);}}>
+                                                onClick={() => {onTabDelete(index + (MAX_TABS - 1));}}>
                                                 <Glyphicon glyph="remove" />
                                             </ConfirmButton>
                                         </OverlayTrigger>

--- a/js/extension/components/PlotSelection.jsx
+++ b/js/extension/components/PlotSelection.jsx
@@ -75,7 +75,7 @@ function PlotTabs({
     onTabChange,
     data,
     plots,
-    onTabDelete = () => {},
+    onTabDelete = (index) => {index},
     onRowsSelected,
     ...props
 }) {
@@ -98,7 +98,7 @@ function PlotTabs({
                                 <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
                                     <ConfirmButton
                                         confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                        onClick={() => {onRowsSelected(); onTabDelete(index);}}>
+                                        onClick={() => {onTabDelete(index);}}>
                                         <Glyphicon glyph="remove" />
                                     </ConfirmButton>
                                 </OverlayTrigger>
@@ -112,7 +112,7 @@ function PlotTabs({
                                         <OverlayTrigger placement="bottom" overlay={<Tooltip><Message msgId={'cadastrapp.search.deleteTab'}/></Tooltip>}>
                                             <ConfirmButton
                                                 confirmContent={<Message msgId={'cadastrapp.search.confirmDeleteTab'}/>}
-                                                onClick={() => {onRowsSelected(); onTabDelete(index);}}>
+                                                onClick={() => {onTabDelete(index);}}>
                                                 <Glyphicon glyph="remove" />
                                             </ConfirmButton>
                                         </OverlayTrigger>

--- a/js/extension/components/lists/ReferencesList.jsx
+++ b/js/extension/components/lists/ReferencesList.jsx
@@ -38,7 +38,7 @@ export default function ReferencesList({ references = [], cgocommune, onAddRefer
                     style={{ marginLeft: 6, marginTop: 4 }}
                     className="pull-left"><Message msgId={'cadastrapp.parcelle.addMoreReference'}/></span>
             </div>
-            <div style={{ width: "100%", height: "calc(50vh - 290px)", minHeight: 96, "overflowY": "visible" }}>
+            <div style={{ width: "100%", minHeight: 96, "overflowY": "visible" }}>
                 {
                     sections && references.map((row, index) => {
                         return (<ReferenceRow

--- a/js/extension/components/lists/StrList.jsx
+++ b/js/extension/components/lists/StrList.jsx
@@ -20,7 +20,7 @@ export function StrList({items = [], onAdd, onRemove, onSetValue}) {
                     className="pull-left"><Message msgId={'cadastrapp.proprietaire.proprietaires.addMoreProprietaire'}/>
                 </span>
             </div>
-            <div style={{ width: "100%", height: "calc(50vh - 290px)", minHeight: 96, "overflowY": "auto" }}>
+            <div style={{ width: "100%", "overflowY": "auto" }}>
                 {items.map((v, index) => (
                     <div style={{ width: "100%", "float": "left" }}>
                         <FormControl

--- a/js/extension/components/search/CoownershipSearch.jsx
+++ b/js/extension/components/search/CoownershipSearch.jsx
@@ -65,18 +65,21 @@ export default function CoownershipSearch({ loading, onSearch = () => { }, onOwn
                     </div>
                 </div>
             </div>
-            <SearchButtons
-                loading={loading}
-                valid={isSearchValid(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER])}
-                onClear={() => resetFormState(SEARCH_TYPES.COOWNER)}
-                onSearch={() => {
-                    if (isString(searchState[SEARCH_TYPES.COOWNER]?.proprietaire) && !values?.parcelle) {
-                        onOwnersSearch(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER]);
-                    } else {
-                        // plot search
-                        onSearch(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER]);
-                    }
+            <div className="searchButtonsContainer">
+                <SearchButtons
+                    className="searchButtons"
+                    loading={loading}
+                    valid={isSearchValid(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER])}
+                    onClear={() => resetFormState(SEARCH_TYPES.COOWNER)}
+                    onSearch={() => {
+                        if (isString(searchState[SEARCH_TYPES.COOWNER]?.proprietaire) && !values?.parcelle) {
+                            onOwnersSearch(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER]);
+                        } else {
+                            // plot search
+                            onSearch(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER]);
+                        }
                 }}/>
+            </div>
         </div>
     );
 }

--- a/js/extension/components/search/CoownershipSearch.jsx
+++ b/js/extension/components/search/CoownershipSearch.jsx
@@ -67,7 +67,7 @@ export default function CoownershipSearch({ loading, onSearch = () => { }, onOwn
             </div>
             <div className="searchButtonsContainer">
                 <SearchButtons
-                    className="searchButtons"
+                    cls="searchButtons"
                     loading={loading}
                     valid={isSearchValid(SEARCH_TYPES.COOWNER, searchState[SEARCH_TYPES.COOWNER])}
                     onClear={() => resetFormState(SEARCH_TYPES.COOWNER)}

--- a/js/extension/components/search/OwnersSearch.jsx
+++ b/js/extension/components/search/OwnersSearch.jsx
@@ -41,13 +41,17 @@ export default function OwnersSearch({ loading, onOwnersSearch = () => {}}) {
                         setValue={(key, value) => setFormState(SEARCH_TYPES.OWNER_LOT, key, value)} />
                 </Tab>
             </Tabs>
-            <SearchButtons
-                loading={loading}
-                valid={isSearchValid(currentTab, searchState[currentTab])}
-                onClear={() => resetFormState(currentTab)}
-                onSearch={() => {
-                    onOwnersSearch(currentTab, searchState[currentTab]);
+            <div className="searchButtonsContainer">
+                <SearchButtons
+                    className="searchButtons"
+                    loading={loading}
+                    valid={isSearchValid(currentTab, searchState[currentTab])}
+                    onClear={() => resetFormState(currentTab)}
+                    onSearch={() => {
+                        onOwnersSearch(currentTab, searchState[currentTab]);
                 }} />
+            </div>
+            
         </div>
     );
 }

--- a/js/extension/components/search/OwnersSearch.jsx
+++ b/js/extension/components/search/OwnersSearch.jsx
@@ -43,7 +43,7 @@ export default function OwnersSearch({ loading, onOwnersSearch = () => {}}) {
             </Tabs>
             <div className="searchButtonsContainer">
                 <SearchButtons
-                    className="searchButtons"
+                    cls="searchButtons"
                     loading={loading}
                     valid={isSearchValid(currentTab, searchState[currentTab])}
                     onClear={() => resetFormState(currentTab)}

--- a/js/extension/components/search/PlotSearch.jsx
+++ b/js/extension/components/search/PlotSearch.jsx
@@ -49,7 +49,7 @@ export default function PlotsSearch({onSearch = () => {}, loading}) {
             </Tabs>
             <div className="searchButtonsContainer">
                 <SearchButtons
-                    className="searchButtons"
+                    cls="searchButtons"
                     loading={loading}
                     valid={isSearchValid(currentTab, searchState[currentTab])}
                     onClear={() => resetFormState(currentTab)}

--- a/js/extension/components/search/PlotSearch.jsx
+++ b/js/extension/components/search/PlotSearch.jsx
@@ -47,12 +47,14 @@ export default function PlotsSearch({onSearch = () => {}, loading}) {
                         setValue={(key, value) => setFormState(SEARCH_TYPES.LOT, key, value)} />
                 </Tab>
             </Tabs>
-            <SearchButtons
-                loading={loading}
-                valid={isSearchValid(currentTab, searchState[currentTab])}
-                onClear={() => resetFormState(currentTab)}
-                onSearch={() => onSearch(currentTab, searchState[currentTab])}
-            />
+            <div>
+                <SearchButtons
+                    loading={loading}
+                    valid={isSearchValid(currentTab, searchState[currentTab])}
+                    onClear={() => resetFormState(currentTab)}
+                    onSearch={() => onSearch(currentTab, searchState[currentTab])}
+                />
+            </div>
         </div>
     );
 }

--- a/js/extension/components/search/PlotSearch.jsx
+++ b/js/extension/components/search/PlotSearch.jsx
@@ -47,8 +47,9 @@ export default function PlotsSearch({onSearch = () => {}, loading}) {
                         setValue={(key, value) => setFormState(SEARCH_TYPES.LOT, key, value)} />
                 </Tab>
             </Tabs>
-            <div>
+            <div className="searchButtonsContainer">
                 <SearchButtons
+                    className="searchButtons"
                     loading={loading}
                     valid={isSearchValid(currentTab, searchState[currentTab])}
                     onClear={() => resetFormState(currentTab)}

--- a/js/extension/components/search/SearchButtons.jsx
+++ b/js/extension/components/search/SearchButtons.jsx
@@ -5,9 +5,9 @@ import { Button, ButtonGroup, Glyphicon } from "react-bootstrap";
 
 
 export default function({
-    loading, valid, onClear = () => {}, onSearch = () => {}
+    loading, valid, onClear = () => {}, onSearch = () => {}, className
 }) {
-    return (<ButtonGroup style={{ margin: "10px", "float": "right" }}>
+    return (<ButtonGroup className={className}>
         {loading ? <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner" /> : null}
         <Button
             onClick={onClear}

--- a/js/extension/components/search/SearchButtons.jsx
+++ b/js/extension/components/search/SearchButtons.jsx
@@ -5,9 +5,9 @@ import { Button, ButtonGroup, Glyphicon } from "react-bootstrap";
 
 
 export default function({
-    loading, valid, onClear = () => {}, onSearch = () => {}, className
+    loading, valid, onClear = () => {}, onSearch = () => {}, cls
 }) {
-    return (<ButtonGroup className={className}>
+    return (<ButtonGroup className={cls}>
         {loading ? <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner" /> : null}
         <Button
             onClick={onClear}

--- a/js/extension/components/table/PlotsSelectionTable.jsx
+++ b/js/extension/components/table/PlotsSelectionTable.jsx
@@ -64,15 +64,21 @@ function PlotsSelectionTable({
         const calculateHeight = () => {
             const parent = document.querySelector(".right-side");
             const parentHeight = document.querySelector(".right-side").clientHeight;
-            // Header size
+            // Header height
             const h3Height = document.querySelector("h3.pull-left").clientHeight;
             const ulSize = document.querySelector(".plots-selection .nav").clientHeight;
-            
+            // Row height min 35px
+            const rowElement = document.querySelector(".plots-selection .react-grid-Row");
+            const rowHeight = rowElement ? rowElement.style.height : 35;
             // add margin if needed to parent to see all the panel on top of footer
             const tabElement = document.querySelector(".plots-selection .tab-content");
             parent.children.length > 2 ? tabElement.style.marginBottom = "50px" : tabElement.style.marginBottom = "";            
 
-            const remainingHeight = parent.children.length > 2 ? Math.max(data.length * 35 + h3Height + ulSize + 30, 200) : Math.max(parentHeight - 220, 200); // 200px min
+            // Calcul tab height needed to display.
+            // +30 add a security bottom margin to avoid scrollbar.
+            // 200 is the minimum height no matter content.
+            // -220 : as the height is based on the total height of cadastrapp component, we need to mount the bottom of the tab.
+            const remainingHeight = parent.children.length > 2 ? Math.max(data.length * rowHeight + h3Height + ulSize + 30, 200) : Math.max(parentHeight - 220, 200);
             setDynamicHeight(remainingHeight);
         };
     

--- a/js/extension/components/table/PlotsSelectionTable.jsx
+++ b/js/extension/components/table/PlotsSelectionTable.jsx
@@ -69,11 +69,11 @@ function PlotsSelectionTable({
             const ulSize = document.querySelector(".plots-selection .nav").clientHeight;
             // Row height min 35px
             const rowElement = document.querySelector(".plots-selection .react-grid-Row");
-            const rowHeight = rowElement ? rowElement.style.height : 35;
+            const rowHeight = rowElement ? parseInt(rowElement.style.height, 10) : 35;
             // add margin if needed to parent to see all the panel on top of footer
             const tabElement = document.querySelector(".plots-selection .tab-content");
-            parent.children.length > 2 ? tabElement.style.marginBottom = "50px" : tabElement.style.marginBottom = "";            
-
+            parent.children.length > 2 ? tabElement.style.marginBottom = "50px" : tabElement.style.marginBottom = "";
+            
             // Calcul tab height needed to display.
             // +30 add a security bottom margin to avoid scrollbar.
             // 200 is the minimum height no matter content.

--- a/js/extension/components/table/PlotsSelectionTable.jsx
+++ b/js/extension/components/table/PlotsSelectionTable.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import { sortBy } from 'lodash';
 import ReactDataGrid from './MultilineHeaderTable';
 import PropTypes from 'prop-types';
@@ -55,12 +55,44 @@ function PlotsSelectionTable({
         }
         return processedRows;
     })(sorting);
+
+    // Calcul height of parcels tab 
+    const [dynamicHeight, setDynamicHeight] = useState(0);
+    const parentChildren = document.querySelector(".right-side").children.length
+    
+    useEffect(() => {
+        const calculateHeight = () => {
+            const parent = document.querySelector(".right-side");
+            const parentHeight = document.querySelector(".right-side").clientHeight;
+            // Header size
+            const h3Height = document.querySelector("h3.pull-left").clientHeight;
+            const ulSize = document.querySelector(".plots-selection .nav").clientHeight;
+            
+            // add margin if needed to parent to see all the panel on top of footer
+            const tabElement = document.querySelector(".plots-selection .tab-content");
+            parent.children.length > 2 ? tabElement.style.marginBottom = "50px" : tabElement.style.marginBottom = "";            
+
+            const remainingHeight = parent.children.length > 2 ? Math.max(data.length * 35 + h3Height + ulSize + 30, 200) : Math.max(parentHeight - 220, 200); // 200px min
+            setDynamicHeight(remainingHeight);
+        };
+    
+        calculateHeight();
+
+        window.addEventListener("click", calculateHeight);
+        window.addEventListener("resize", calculateHeight);
+        return () => {
+            window.removeEventListener("click", calculateHeight);
+            window.removeEventListener("resize", calculateHeight);
+        }
+    }, [data, parentChildren]);
+
+    
     return (<ReactDataGrid
         sortable
         onRowDoubleClick={onRowDoubleClick}
         rowGetter={i => rows[i]}
         rowsCount={rows.length}
-        minHeight={230}
+        minHeight={dynamicHeight}
         columns={columns}
         onGridSort={(sortColumn, sortDirection) => {
             // sortDirection: "ASC", "DESC", "NONE"

--- a/js/extension/plugins/cadastrapp/PlotSelection.jsx
+++ b/js/extension/plugins/cadastrapp/PlotSelection.jsx
@@ -44,7 +44,7 @@ const PlotsSelection = connect((state) => ({
     removePlots: removePlots,
     zoomToSelection: zoomToSelection,
     showLandedPropertyInformationByParcelle,
-    onTabDelete: () => removePlotSelection(),
+    onTabDelete: (index) => removePlotSelection(index),
     onSaveAsAnnotation: saveAsAnnotation
 })(PS);
 

--- a/js/extension/reducers/cadastrapp.js
+++ b/js/extension/reducers/cadastrapp.js
@@ -193,6 +193,8 @@ export default function cadastrapp(state = DEFAULT_STATE, action) {
     case REMOVE_PLOT_SELECTION: {
         const active = action.active ?? state.activePlotSelection;
         const newPlots = [...state.plots.filter((_, i) => i !== active)];
+        console.log({active});
+        console.log({newPlots});
         return compose(
             set(`plots`, newPlots),
             set(`activePlotSelection`, Math.max(state.activePlotSelection - 1, 0))

--- a/js/extension/reducers/cadastrapp.js
+++ b/js/extension/reducers/cadastrapp.js
@@ -193,8 +193,6 @@ export default function cadastrapp(state = DEFAULT_STATE, action) {
     case REMOVE_PLOT_SELECTION: {
         const active = action.active ?? state.activePlotSelection;
         const newPlots = [...state.plots.filter((_, i) => i !== active)];
-        console.log({active});
-        console.log({newPlots});
         return compose(
             set(`plots`, newPlots),
             set(`activePlotSelection`, Math.max(state.activePlotSelection - 1, 0))


### PR DESCRIPTION
Multiple changes to the parcel search interface:
- the ‘+’ button is now placed after the tabs used to search for plots, like a web browser.
- tab deletion is now done by a cross on each tab. The dustbin has been removed.
- the ‘search’ and ‘delete’ buttons have been grouped together in the plot search block to avoid confusion with the plot selection block below. 

These changes have been reflected in the search for owners and co-owners to maintain the overall consistency of cadastrapp.

Tested in integration.
Mapstore 2023.02
Node 16.20.2